### PR TITLE
feat: defrost/idle detection, setpoint-drop zone, profile slope sensors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,8 +70,5 @@ python -m pytest tests/test_X.py -q # run one file
 
 - **Avoid over-engineering**: only add code that directly addresses the requirement
 - **No second-order slope terms**: VTherm slope is already EMA-smoothed; parabolic projection amplifies noise
-- **One step at a time**: fan speed changes are always limited to ±1 step (braking, recovery)
-- **MPC shadow is read-only**: it must never call any HA service or modify controller state
-protoart climate control- **MPC shadow pauses during defrost**: like window-open, it returns "Disturbed" and decays the disturbance bias without updating it
-- **MPC shadow pauses during HVAC idle**: same as defrost — returns "Disturbed" and decays the disturbance bias
+- **Step-limited fan changes**: braking is limited to -1 step; recovery is usually +1 step, but Zone C may step up by +2 when error exceeds `0.75*hard_error`
 - **Learning data integrity**: exclude window-open, defrost, and HVAC idle periods from slope samples and response-time events

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,77 @@
+# Smart Fan Controller — Project Guidelines
+
+## Architecture
+
+The integration lives under `custom_components/smart_fan_controller/`. Key modules:
+
+| File | Role |
+|------|------|
+| `controller.py` | `SmartFanController` — rule-based decision engine (zones A–F) |
+| `mpc_shadow.py` | `MPCShadowController` — observation-only MPC-lite, never writes fan commands |
+| `thermal_learning.py` | `ThermalLearning` — slope samples, response-time events, profile calibration |
+| `__init__.py` | HA integration entry point: config, control loop, services |
+| `config_flow.py` | Config and options UI flows |
+| `sensor.py` / `switch.py` | HA entity platforms |
+| `data_collection.py` | CSV logger for offline analysis |
+
+## Domain Vocabulary
+
+- **error**: always positive when the system needs more heating/cooling (`target - current` in heat, `current - target` in cool)
+- **effective_slope**: `vtherm_slope` (°C/h, EMA-smoothed by Versatile Thermostat)
+- **dead_time**: thermal lag between a fan change and first observable slope response
+- **defrost_active**: heat-pump defrost cycle (auto-detected or via external entity); blocks step-down decisions and learning samples
+- **hvac_idle**: heat-pump compressor is off (detected via operating entity or power consumption); blocks step-up decisions (zones C, D) and learning samples — no cooldown unlike defrost
+- **Zones A–F**: priority-ordered decision rules; zone A = emergency/setpoint-drop, F = comfort hold
+
+## Decision Engine Zones (in priority order)
+
+| Zone   | Condition                                           | Action needed to modify       |
+|--------|-----------------------------------------------------|-------------------------------|
+| A      | `error ≥ hard_error` OR `error < TARGET_DROP (-1°C)` | `controller.py:_decide_zone_a` |
+| B      | Projected overshoot > deadband AND slope changed    | `controller.py:_decide_zone_b` |
+| C      | `error > soft_error`                                | `controller.py:_decide_zone_c` |
+| D      | `0 < error < soft_error`                            | `controller.py:_decide_zone_d` |
+| E      | `error < -deadband`                                 | `controller.py:_decide_zone_e` |
+| F      | `-deadband ≤ error ≤ 0`                             | `controller.py:_decide_zone_f` |
+
+## Test Conventions
+
+- Framework: **pytest** in `tests/`; run with `python -m pytest tests/ -q`
+- Never use `time.sleep`; mock `time.time` via `unittest.mock.patch`
+- Protected-member access (`controller._state`) is normal in tests — add `# pylint: disable=protected-access` at module top
+- Fixtures that shadow outer names need `# pylint: disable=redefined-outer-name`
+- Every test function and helper needs a docstring
+- HA switch classes only implement `async_turn_on`/`async_turn_off` — add `# pylint: disable=abstract-method` on the class
+
+## Home Assistant Patterns
+
+- Switches inherit `SwitchEntity` and only override async variants; sync `turn_on`/`turn_off` are intentionally omitted
+- `async_write_ha_state()` is called after any state mutation in switch/sensor entities
+- Config flow uses `vol.Schema` with selectors from `homeassistant.helpers.selector`
+- Entity IDs are built with `build_entity_id()` / `build_unique_id()` from `const.py`
+
+## Build & Test
+
+```bash
+python -m pytest tests/ -q          # run all tests
+python -m pytest tests/test_X.py -q # run one file
+./container coverage                 # coverage via Docker container
+./container hassfest                 # validate manifest / translations
+```
+
+## Key Constants (const.py)
+
+- `THRESHOLD_TARGET_DROP = -1.0` — setpoint-drop trigger (°C)
+- `DEFAULT_DEADBAND`, `DEFAULT_SOFT_ERROR`, `DEFAULT_HARD_ERROR` — all tunable via options flow
+- `CONF_DEFROST_ENTITY` — optional entity for external defrost signal
+- `CONF_OPERATING_ENTITY` — optional entity for heat-pump compressor running state
+
+## Important Constraints
+
+- **Avoid over-engineering**: only add code that directly addresses the requirement
+- **No second-order slope terms**: VTherm slope is already EMA-smoothed; parabolic projection amplifies noise
+- **One step at a time**: fan speed changes are always limited to ±1 step (braking, recovery)
+- **MPC shadow is read-only**: it must never call any HA service or modify controller state
+protoart climate control- **MPC shadow pauses during defrost**: like window-open, it returns "Disturbed" and decays the disturbance bias without updating it
+- **MPC shadow pauses during HVAC idle**: same as defrost — returns "Disturbed" and decays the disturbance bias
+- **Learning data integrity**: exclude window-open, defrost, and HVAC idle periods from slope samples and response-time events

--- a/.github/skills/add-control-zone/SKILL.md
+++ b/.github/skills/add-control-zone/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: add-control-zone
+description: "Add, modify, or remove a decision zone (A–F) in the SmartFanController decision engine. Use when: adding a new zone or sub-rule to controller.py; modifying zone conditions or actions; renaming or reordering zones; ensuring tests, README, and copilot-instructions.md stay in sync with zone changes."
+argument-hint: "Zone letter and description of the new behavior (e.g. 'Zone D sub-rule: step down if slope favorable for 3+ cycles')"
+---
+
+# Add or Modify a Control Zone
+
+## Decision Engine Overview
+
+Zones are evaluated in strict priority order in `controller.py → calculate_decision()`.
+Each zone has a dedicated `_decide_zone_X()` method. The first zone whose condition matches returns the decision.
+
+Current order: **A → B → C → D → E → F**
+
+## Procedure
+
+### 1. Understand the Impact
+- Read the existing zone method and its condition
+- Check if the new condition overlaps with adjacent zones
+- Confirm the action respects the ±1 step limit
+
+### 2. Modify `controller.py`
+
+**Zone condition change**: Edit `calculate_decision()` where the zone's `if` block lives.
+
+**Zone action change**: Edit `_decide_zone_X()`.
+
+**New sub-rule inside a zone**: Add a nested `if/elif` inside `_decide_zone_X()`.
+
+**New zone**: Insert a new `if` block in `calculate_decision()` at the correct priority position and create `_decide_zone_X()`.
+
+Constraints:
+- Fan changes must be `±1` step — use `min(current_index + 1, max_index)` / `max(current_index - 1, 0)`
+- `force=True` bypasses `min_interval`; use only for emergency/setpoint-drop
+- Return `{"fan_mode": ..., "reason": ..., "force": ..., "zone": ...}` from the zone method
+- Defrost protection zones (B, D step-down paths): verify defrost guard is still respected
+
+### 3. Update `const.py` (if needed)
+New threshold constants go in `const.py` with a `DEFAULT_` prefix and exposed in `config_flow.py` if user-tunable.
+
+### 4. Write Tests
+Create or extend `tests/test_heat.py` / `tests/test_cool.py` / a dedicated file.
+
+Test template:
+```python
+# pylint: disable=protected-access,redefined-outer-name
+"""Tests for Zone X: <description>."""
+
+import pytest
+from unittest.mock import patch
+from custom_components.smart_fan_controller.controller import SmartFanController
+
+@pytest.fixture
+def controller():
+    """Create a SmartFanController for zone tests."""
+    return SmartFanController(
+        fan_modes=["silent", "low", "med", "high", "superhigh"],
+        deadband=0.2, min_interval=10, soft_error=0.3, hard_error=0.6,
+    )
+
+def test_zone_x_<condition>(controller):
+    """<Zone letter>: <what this tests>."""
+    with patch("time.time", return_value=3600.0):
+        result = controller.calculate_decision(
+            current_temp=..., target_temp=...,
+            vtherm_slope=..., hvac_mode="heat", current_fan="med",
+        )
+    assert result["fan_mode"] == ...
+    assert "<expected reason substring>" in result["reason"]
+```
+
+Run after editing: `python -m pytest tests/ -q`
+
+### 5. Update Documentation
+
+**`README.md`** — Decision Priority table in the Control Logic section.
+
+**`.github/copilot-instructions.md`** — Decision Engine Zones table.
+
+**`services.yaml`** (if the zone interacts with services).
+
+### 6. Validate
+
+```bash
+python -m pytest tests/ -q          # all tests pass
+./container hassfest                # manifest / translations valid
+```

--- a/.github/skills/analyze-control-data/SKILL.md
+++ b/.github/skills/analyze-control-data/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: analyze-control-data
+description: "Analyze Smart Fan Controller CSV data files to diagnose algorithm behavior, identify missed MPC opportunities, detect defrost artifacts, and propose improvements. Use when: the user provides a CSV data file; asking to analyze overnight or morning behavior; asking why the fan did or did not change; evaluating MPC shadow accuracy; diagnosing defrost or setpoint-drop events."
+argument-hint: "CSV file path or description of the behavior to diagnose"
+---
+
+# Analyze Control Data
+
+## When to Use
+
+- User provides a `smart_fan_controller_data_*.csv` file (from `data/`)
+- User describes unexpected behavior ("fan stayed on med all night", "slow morning rise")
+- User wants to compare MPC shadow decisions vs live decisions
+- Diagnosing defrost artifacts, setpoint drops, or window-open disturbances
+
+## Column Reference
+
+| Column | Meaning |
+|--------|---------|
+| `timestamp` | ISO datetime of each control cycle (~2 min intervals) |
+| `hvac_mode` | `heat` or `cool` |
+| `current_temp` | Sensor temperature (°C) |
+| `target_temp` | Active setpoint (°C) |
+| `vtherm_slope` | EMA-smoothed slope from VTherm (°C/h) |
+| `error` | Signed error (positive = needs action) |
+| `current_fan` | Fan mode at start of cycle |
+| `fan_mode` | Fan mode selected by controller |
+| `reason` | Zone decision reason string |
+| `phase` | `DEAD_TIME` / `TRANSIENT` / `ESTABLISHED` |
+| `effective_slope` | Slope actually used for decisions |
+| `is_window_open` | `True`/`False` |
+| `force` | `True` if timer was bypassed |
+| `mpc_shadow_fan_mode` | Fan mode the shadow would choose |
+| `mpc_shadow_status` | `Ready` / `Disabled` / `Setpoint drop` / `Disturbed` |
+| `mpc_shadow_matches_live` | `yes` / `no` / `disabled` |
+| `mpc_shadow_would_change` | `yes` / `no` |
+| `mpc_shadow_cost` | MPC optimization cost |
+| `mpc_shadow_confidence` | Profile coverage % |
+| `mpc_shadow_reason` | Shadow decision explanation |
+| `defrost_active` | `True` when defrost protection is active |
+| `learning_ready` | `True` when ≥10 samples per profile |
+
+## Analysis Procedure
+
+### 1. Load and Inspect
+- Read the CSV with pandas or csv module
+- Check time range, number of rows, unique HVAC modes
+- Identify gaps (missing cycles, restarts)
+
+### 2. Key Diagnostic Checks
+
+**Setpoint drop events (`reason` contains "Setpoint drop")**
+- Check `target_temp` drop magnitude
+- Verify `fan_mode` went to lowest mode
+- Check MPC shadow also reported "Setpoint drop"
+
+**Defrost events (`defrost_active == True`)**
+- Find the slope drop that triggered detection: look for `vtherm_slope` crossing sharply negative
+- Verify zones B/D were blocked (reason should contain "Defrost hold")
+- Check duration: 20-min cooldown from detection to next step-down
+
+**MPC divergence periods (`mpc_shadow_matches_live == "no"`)**
+- Identify what shadow chose vs live
+- Check `mpc_shadow_confidence` — low confidence = not enough learning data
+- Check `mpc_shadow_known_profiles` — shadow needs ≥10 samples per mode
+
+**Slow temperature recovery**
+- Plot `current_temp` vs `target_temp` over time
+- Look for unnecessary step-downs (reason "Maintenance: favorable slope" or "Braking")
+- Cross-check with `defrost_active` — was defrost correctly detected?
+
+**Night setpoint drop mismatch (MPC on "med" instead of "silent")**
+- Filter to period where `target_temp` dropped significantly
+- Check `mpc_shadow_status` — should be "Setpoint drop" with lowest fan
+- If not, the snapshot was taken before the setpoint-drop fix was deployed
+
+### 3. Report Format
+
+Provide a narrative structured as:
+1. **Period summary**: time range, hvac mode, temperature trajectory
+2. **Key events**: defrost cycles, setpoint drops, fan changes — with timestamps
+3. **Algorithm assessment**: zones triggered correctly? any missed steps?
+4. **MPC shadow comparison**: agreement rate, key divergences and their cause
+5. **Recommendations**: concrete parameter changes or code fixes if warranted
+
+## Code Hints
+
+- Load CSV: `pd.read_csv(path, parse_dates=["timestamp"])`
+- Filter defrost: `df[df["defrost_active"] == True]`
+- Find mode changes: `df[df["current_fan"] != df["fan_mode"]]`
+- MPC divergence: `df[df["mpc_shadow_matches_live"] == "no"]`
+- Zone summary: `df["reason"].value_counts()`

--- a/.github/skills/modify-mpc-shadow/SKILL.md
+++ b/.github/skills/modify-mpc-shadow/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: modify-mpc-shadow
+description: "Modify the MPC shadow controller: cost function tuning, hysteresis thresholds, simulation model, disturbance tracking, or adding new pausing conditions. Use when: changing how the shadow evaluates or recommends fan modes; adjusting cost weights or switch-gain margins; adding new disturbance sources; modifying the step-down hold logic; changing how confidence is computed."
+argument-hint: "Description of the MPC shadow behavior to change (e.g. 'reduce overshoot penalty weight')"
+---
+
+# Modify MPC Shadow Controller
+
+## Architecture
+
+The MPC shadow lives in `mpc_shadow.py` as `MPCShadowController`. It is **read-only**: it never calls HA services or modifies the live controller. It runs every control cycle (~2 min) and produces a recommendation dict that feeds sensors and CSV logs.
+
+### Key Flow in `evaluate()`
+
+```
+1. Early exits: disabled, idle HVAC mode
+2. Resolve fan modes and active fan
+3. Compute effective slope, dead time, phase
+4. Update disturbance bias (EMA tracking)
+5. Pause conditions: window-open, defrost → return "Disturbed"
+6. Setpoint drop → return lowest mode immediately
+7. Simulate ALL fan modes over the horizon (30 min default)
+8. Select best by lowest cost
+9. Apply guards: min-interval hold, hysteresis, step-down hold, step-down limit
+10. Build and return payload
+```
+
+### Cost Function (`_simulate_mode`)
+
+Each candidate fan mode is simulated step-by-step over the horizon:
+
+| Cost Component | Weight | Purpose |
+|---|---|---|
+| `comfort_error × urgency` | 1.0 × (1 + excess error × 2) | Penalizes being outside deadband |
+| `overshoot²` | 3.0 | Strongly penalizes going past target |
+| `floor_violation` (linear) | 12.0 × urgency | Penalizes being below target (heat) |
+| `floor_violation²` | 30.0 | Strongly penalizes large shortfalls |
+| `mode_change_cost` | 0.15 × distance | Penalizes switching fan modes |
+| `mode_rank_cost` | 0.05 × (rank+1) | Slight preference for lower fan speeds |
+| `min_interval_penalty` | 25.0 | Blocks changes before min_interval |
+
+### Hysteresis (`_required_switch_gain`)
+
+The shadow requires a minimum cost improvement before switching:
+
+| Situation | Base Margin |
+|---|---|
+| Over-target or far under | 0.10 |
+| Approaching target | 0.15 |
+| Near target (within deadband) | 0.30 |
+
+Plus bonuses for non-established phase (+0.10) and step distance (+0.05/step).
+
+### Step-Down Guards
+
+- `_step_down_hold_note()`: blocks downward moves when still under target and either not established or predicted shortfall at 10 min
+- `_apply_step_down_limit()`: enforces ±1 step per cycle for downward moves (upward is unrestricted)
+
+### Disturbance Bias (`_update_disturbance_bias`)
+
+Tracks slow external perturbations (solar, occupancy). Only updates during ESTABLISHED phase with a known profile. Decays during window-open or defrost. Clamped to ±2.0 °C/h.
+
+### Pause Conditions
+
+The shadow pauses (returns "Disturbed") during:
+- **Window open**: thermal model unreliable
+- **Defrost active**: slope data is corrupted by heat-pump defrost cycle
+
+Both conditions decay the disturbance bias without updating it.
+
+## Procedure
+
+### 1. Identify the Change Area
+
+| Change | File/Method |
+|---|---|
+| Cost weights | `_simulate_mode()` constants at module top |
+| Hysteresis margins | `_required_switch_gain()` constants at module top |
+| Step-down guard | `_step_down_hold_note()` |
+| New pause condition | `evaluate()` after disturbance update, before setpoint-drop check |
+| Disturbance tracking | `_update_disturbance_bias()` |
+| Simulation model | `_simulate_mode()` inner loop |
+| Confidence | `_compute_confidence()` |
+
+### 2. Make the Change
+
+Constants are at the module level (e.g., `FLOOR_VIOLATION_LINEAR_WEIGHT = 12.0`). If a new constant is user-tunable, add it to `const.py` with `DEFAULT_` prefix and expose in `config_flow.py`.
+
+Key constraints:
+- **Never call HA services** from the shadow
+- **Never modify controller state** — the shadow is observation-only
+- **Respect the payload format** — all keys must start with `mpc_shadow_`
+- **Log at DEBUG level** — shadow logs are verbose by design
+
+### 3. Write Tests
+
+Tests go in `tests/test_mpc_shadow.py`. Use the existing helpers:
+
+```python
+def test_shadow_<behavior>() -> None:
+    """<What this tests>."""
+    controller = _build_controller()
+    _prime_learning_profiles(controller)
+    shadow = MPCShadowController(
+        learning=controller.learning,
+        deadband=0.3,
+        min_interval=10,
+        fan_modes=FAN_MODES,
+        enabled=True,
+    )
+
+    result = shadow.evaluate(
+        current_temp=..., target_temp=...,
+        vtherm_slope=..., hvac_mode="heat",
+        current_fan="medium", live_decision_fan="medium",
+        is_window_open=False, minutes_since_change=20.0,
+    )
+
+    assert result["mpc_shadow_fan_mode"] == ...
+    assert result["mpc_shadow_status"] == ...
+```
+
+### 4. Update Documentation
+
+- **`README.md`** — MPC Shadow section if user-visible behavior changes
+- **`docs/mpc_shadow_mode.md`** — technical design document
+- **`.github/copilot-instructions.md`** — if adding new constraints
+
+### 5. Validate
+
+```bash
+python -m pytest tests/test_mpc_shadow.py -q   # shadow tests
+python -m pytest tests/ -q                      # all tests
+```

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,12 @@ jobs:
         name: Run tests
         steps:
             - name: Check out repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
-                  python-version: "3.11"
+                  python-version: "3.13"
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,12 +13,12 @@ jobs:
     name: Validate custom component
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Validate Python syntax
         run: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Predictive fan speed control for HVAC systems, designed to work with Versatile T
 - [Smart Fan Controller — Home Assistant Custom Integration](#smart-fan-controller--home-assistant-custom-integration)
   - [Table of Contents](#table-of-contents)
   - [Installation](#installation)
+    - [HACS (Recommended)](#hacs-recommended)
+    - [Manual Installation](#manual-installation)
   - [Overview](#overview)
+    - [How It Works](#how-it-works)
   - [Requirements](#requirements)
   - [Quick Setup](#quick-setup)
   - [Configuration Parameters](#configuration-parameters)
@@ -20,12 +23,21 @@ Predictive fan speed control for HVAC systems, designed to work with Versatile T
     - [Temperature Projection](#temperature-projection)
     - [Phase Detection](#phase-detection)
     - [Safety Constraints](#safety-constraints)
+    - [Defrost Detection](#defrost-detection)
+    - [HVAC Idle Detection](#hvac-idle-detection)
   - [Learning System](#learning-system)
     - [Per-Mode Fan Profiles](#per-mode-fan-profiles)
     - [Dead Time Calibration](#dead-time-calibration)
     - [Window-Open Filtering](#window-open-filtering)
-  - [Sensors & Entities](#sensors--entities)
+    - [Defrost Learning Exclusion](#defrost-learning-exclusion)
+    - [HVAC Idle Learning Exclusion](#hvac-idle-learning-exclusion)
+  - [Sensors \& Entities](#sensors--entities)
+    - [Main Entities](#main-entities)
+    - [Diagnostic Sensors](#diagnostic-sensors)
+    - [Defrost Diagnostic](#defrost-diagnostic)
   - [Services](#services)
+    - [`smart_fan_controller.apply_learned_settings`](#smart_fan_controllerapply_learned_settings)
+    - [`smart_fan_controller.reset_learning`](#smart_fan_controllerreset_learning)
   - [Troubleshooting](#troubleshooting)
   - [License](#license)
 
@@ -66,6 +78,10 @@ Smart Fan Controller is a custom Home Assistant integration that **adjusts HVAC 
 4. Evaluates six priority zones (A–F) and selects the first matching action
 5. Applies safety guards (step-down limit, min interval) and changes fan speed if needed
 6. Collects learning data to automatically calibrate parameters over time
+7. Optionally runs an MPC shadow controller in the background for dry-run comparison
+
+> Experimental: **MPC Shadow Mode** runs a learned temperature-state model and MPC-lite in observation-only mode. It owns its own runtime parameters (`deadband`, `min_interval`, fan modes), never applies real fan commands, pauses itself during disturbed periods such as an open window, and keeps those periods out of dead-time learning. See [docs/mpc_shadow_mode.md](docs/mpc_shadow_mode.md).
+> It supports both `heat` and `cool`, and includes a hysteresis guard so tiny cost differences do not create fan yo-yo around the setpoint.
 
 ---
 
@@ -89,14 +105,16 @@ Smart Fan Controller is a custom Home Assistant integration that **adjusts HVAC 
 
 All parameters can be changed at any time via **Settings → Devices & Services → Smart Fan Controller → Configure**.
 
-| Parameter            | Default  | Range            | Description                                                                                     |
-| -------------------- | -------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| **Deadband**         | `0.2°C`  | `0.0` – `5.0°C`  | Comfort zone around target — no action taken within this range. Increase to reduce fan changes. |
-| **Min Interval**     | `10 min` | `1` – `60 min`   | Minimum time between non-emergency fan changes. Prevents rapid oscillations.                    |
-| **Soft Error**       | `0.3°C`  | `0.0` – `10.0°C` | Error threshold that triggers recovery mode. Should be larger than deadband.                    |
-| **Hard Error**       | `0.6°C`  | `0.0` – `10.0°C` | Error threshold that triggers emergency mode (max fan, bypasses min interval).                  |
-| **Limit Timeout**    | `15 min` | `10` – `120 min` | Maximum time before forcing a re-evaluation, even without significant slope change.             |
-| **Learning Enabled** | `true`   | —                | Enables the automatic learning system. Disable for fully manual tuning.                         |
+| Parameter            | Default  | Range            | Description                                                                                                                                                                                                   |
+| -------------------- | -------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Deadband**         | `0.2°C`  | `0.0` – `5.0°C`  | Comfort zone around target — no action taken within this range. Increase to reduce fan changes.                                                                                                               |
+| **Min Interval**     | `10 min` | `1` – `60 min`   | Minimum time between non-emergency fan changes. Prevents rapid oscillations.                                                                                                                                  |
+| **Soft Error**       | `0.3°C`  | `0.0` – `10.0°C` | Error threshold that triggers recovery mode. Should be larger than deadband.                                                                                                                                  |
+| **Hard Error**       | `0.6°C`  | `0.0` – `10.0°C` | Error threshold that triggers emergency mode (max fan, bypasses min interval).                                                                                                                                |
+| **Limit Timeout**    | `15 min` | `10` – `120 min` | Maximum time before forcing a re-evaluation, even without significant slope change.                                                                                                                           |
+| **Learning Enabled** | `true`   | —                | Enables the automatic learning system. Disable for fully manual tuning.                                                                                                                                       |
+| **MPC Shadow Mode**  | `false`  | —                | Runs the learned model + MPC-lite in the background for comparison only. No real fan command is applied.                                                                                                      |
+| **Defrost Entity**   | *(none)* | —                | Optional entity (`binary_sensor`, `sensor`, or `input_boolean`) that reports when the heat pump is in defrost cycle. When active, defrost protection is applied. See [Defrost Detection](#defrost-detection). |
 
 > **Tip — recommended ratios**: `deadband < soft_error < hard_error`, e.g. `0.2 / 0.3 / 0.6`.
 
@@ -157,6 +175,31 @@ The default dead time is 10 minutes. When the learning system is ready, it is re
 - **Step-down protection**: Fan speed can only decrease by one step at a time (e.g., `turbo → high`), preventing abrupt pressure changes and protecting the motor.
 - **Min interval**: Non-emergency changes respect the effective timeout. Emergency (Zone A) and setpoint drop (Zone A-bis) override it.
 
+### Defrost Detection
+
+When a heat pump defrosts its outdoor coil, the heat output drops sharply — the HVAC is working to melt ice, not heat the room. Without defrost awareness, the controller would misinterpret the falling temperature slope as insufficient fan speed and try to increase it, or worse, would reduce the fan thinking the slope is already favorable when in fact the defrost is about to end.
+
+**External entity (optional)**: Configure a `binary_sensor`, `sensor`, or `input_boolean` from your PAC integration that reports defrost state. When this entity is `on`/`true`/`1`, defrost protection is activated and the 20-minute cooldown timer is refreshed every control cycle — protection stays active *as long as the entity reports defrost*, then the cooldown applies after it clears.
+
+**During defrost protection**:
+- **Zones B and D are blocked**: no step-down decisions (braking or favorable-slope reduction)
+- The decision reason appears as `"Defrost hold: …"`
+- **Learning samples are excluded**: slope data during defrost is not added to per-mode profiles, preventing corrupted calibration
+
+### HVAC Idle Detection
+
+When the heat pump compressor is off (setpoint reached, system coasting) the HVAC is not actively heating or cooling and the fan should not be increased in response to a small temperature drift.
+
+**Operating entity (optional)**: Configure a `binary_sensor`, `sensor`, or `input_boolean` from your PAC integration that reports whether the compressor is running. When this entity is `off`/`false`/`0`, the compressor is considered idle.
+
+> When no operating entity is configured, HVAC idle detection is disabled.
+
+**During HVAC idle**:
+- **Zones C and D are held**: no step-up decisions while the compressor is off
+- The decision reason appears as `"HVAC idle: compressor off, holding current speed"`
+- **Zones A, A-bis, B, and E are unaffected**: emergency, setpoint-drop, braking, and step-down decisions still operate normally
+- **Learning samples are excluded**: slope and response-time data while idle is not added to profiles (see [HVAC Idle Learning Exclusion](#hvac-idle-learning-exclusion))
+
 ---
 
 ## Learning System
@@ -170,11 +213,11 @@ The integration includes an **automatic learning system** that collects data dur
 
 **Parameters computed from data**:
 
-| Parameter       | Formula                                   |
-| --------------- | ----------------------------------------- |
-| `deadband`      | `0.15 + (volatility_factor × 0.2)`        |
-| `soft_error`    | `0.25 + (volatility_factor × 0.3)`        |
-| `hard_error`    | `0.5 + (volatility_factor × 0.4)`         |
+| Parameter       | Formula                                           |
+| --------------- | ------------------------------------------------- |
+| `deadband`      | `0.15 + (volatility_factor × 0.2)`                |
+| `soft_error`    | `0.25 + (volatility_factor × 0.3)`                |
+| `hard_error`    | `0.5 + (volatility_factor × 0.4)`                 |
 | `limit_timeout` | rounded median of measured thermal response times |
 
 Where `volatility_factor = min(slope_stdev / slope_mean, 3.0)`.
@@ -183,7 +226,7 @@ Where `volatility_factor = min(slope_stdev / slope_mean, 3.0)`.
 
 Once learning is ready, parameters are **automatically applied** and the integration reloads. To apply manually, use the `apply_learned_settings` service. To start over, use `reset_learning`.
 
-**Control**: Enable or disable learning at any time via `switch.smart_fan_learning_enabled`. Existing data is preserved when disabled.
+**Control**: Enable or disable learning at any time via `switch.smart_fan_controller_learning_enabled`. Existing data is preserved when disabled.
 
 ### Per-Mode Fan Profiles
 
@@ -200,10 +243,19 @@ Response events are only recorded when the delay is between 2 and 60 minutes (fi
 ### Window-Open Filtering
 
 When Versatile Thermostat reports a window as open (via the `window_manager.window_state` attribute), the controller:
-- **Continues making fan decisions** normally (the HVAC system is still running)
-- **Stops collecting learning data**, since slope readings during open windows are not representative of normal thermal behavior
+- **Continues making live heuristic fan decisions** normally (the HVAC system is still running)
+- **Stops collecting learning data**, including both per-mode slope samples and response-time events used to learn `dead_time`
+- **Pauses the MPC shadow model**, marking it as disturbed instead of trusting predictions during the perturbation
 
 This prevents window-open periods from corrupting the learned profiles.
+
+### Defrost Learning Exclusion
+
+Slope samples and response-time events collected during an active defrost period (auto-detected or via external entity, including the 20-minute cooldown) are **not added to learned profiles**. Defrost distorts the effective slope per fan mode and would bias the learning system toward lower heating capacity estimates.
+
+### HVAC Idle Learning Exclusion
+
+Slope samples and response-time events collected while the compressor is detected as idle (via `operating_entity` or `power_entity`) are **not added to learned profiles**. When the compressor is off the measured slope reflects ambient drift rather than active heating or cooling capacity, and recording it would corrupt per-mode profiles and dead-time calibration.
 
 ---
 
@@ -211,30 +263,50 @@ This prevents window-open periods from corrupting the learned profiles.
 
 ### Main Entities
 
-| Entity                              | Type   | Description                                 |
-| ----------------------------------- | ------ | ------------------------------------------- |
-| `sensor.smart_fan_fan_mode`         | Sensor | Current fan mode selected by the controller |
-| `sensor.smart_fan_status`           | Sensor | Current control zone and decision reason    |
-| `switch.smart_fan_learning_enabled` | Switch | Enable / disable the learning system        |
+| Entity                                         | Type   | Description                                       |
+| ---------------------------------------------- | ------ | ------------------------------------------------- |
+| `sensor.smart_fan_controller_fan_mode`         | Sensor | Current fan mode selected by the controller       |
+| `sensor.smart_fan_controller_status`           | Sensor | Current control zone and decision reason          |
+| `switch.smart_fan_controller_learning_enabled` | Switch | Enable / disable the learning system              |
+| `switch.smart_fan_controller_mpc_shadow_mode`  | Switch | Enable / disable observation-only MPC shadow mode |
 
 ### Diagnostic Sensors
 
-| Entity                                         | Unit  | Description                                         |
-| ---------------------------------------------- | ----- | --------------------------------------------------- |
-| `sensor.smart_fan_temperature_error`           | °C    | Current temperature error (positive = needs action) |
-| `sensor.smart_fan_projected_temperature`       | °C    | Predicted temperature 10 minutes ahead              |
-| `sensor.smart_fan_projected_temperature_error` | °C    | Predicted error 10 minutes ahead                    |
-| `sensor.smart_fan_minutes_since_last_change`   | min   | Time elapsed since last fan mode change             |
-| `sensor.smart_fan_learning_progress`           | %     | Learning completion (100% = ≥240 samples)           |
-| `sensor.smart_fan_learning_status`             | —     | `"Learning (45%)"` or `"Ready"`                     |
-| `sensor.smart_fan_learning_samples`            | count | Number of slope samples collected                   |
-| `sensor.smart_fan_learning_response_events`    | count | Number of thermal response time measurements        |
-| `sensor.smart_fan_learned_dead_time`           | min   | Median learned thermal response delay (`dead_time`) |
-| `sensor.smart_fan_effective_timeout`           | min   | Actual non-emergency timeout currently used         |
-| `sensor.smart_fan_learned_deadband`            | °C    | Learned optimal deadband                            |
-| `sensor.smart_fan_learned_soft_error`          | °C    | Learned optimal soft error threshold                |
-| `sensor.smart_fan_learned_hard_error`          | °C    | Learned optimal hard error threshold                |
-| `sensor.smart_fan_learned_limit_timeout`       | min   | Learned base timeout stored in config               |
+| Entity                                                                | Unit  | Description                                                                |
+| --------------------------------------------------------------------- | ----- | -------------------------------------------------------------------------- |
+| `sensor.smart_fan_controller_temperature_error`                       | °C    | Current temperature error (positive = needs action)                        |
+| `sensor.smart_fan_controller_temperature_projected_10_min`            | °C    | Predicted temperature 10 minutes ahead                                     |
+| `sensor.smart_fan_controller_temperature_projected_error_10_min`      | °C    | Predicted error 10 minutes ahead                                           |
+| `sensor.smart_fan_controller_fan_mode_last_change`                    | min   | Time elapsed since last fan mode change                                    |
+| `sensor.smart_fan_controller_learning_progress`                       | %     | Learning completion (100% = ≥240 samples)                                  |
+| `sensor.smart_fan_controller_learning_status`                         | —     | `"Learning (45%)"` or `"Ready"`                                            |
+| `sensor.smart_fan_controller_learning_samples`                        | count | Number of slope samples collected                                          |
+| `sensor.smart_fan_controller_learning_response_events`                | count | Number of thermal response time measurements                               |
+| `sensor.smart_fan_controller_learned_dead_time`                       | min   | Median learned thermal response delay (`dead_time`)                        |
+| `sensor.smart_fan_controller_effective_timeout`                       | min   | Actual non-emergency timeout currently used                                |
+| `sensor.smart_fan_controller_learned_deadband`                        | °C    | Learned optimal deadband                                                   |
+| `sensor.smart_fan_controller_learned_soft_error`                      | °C    | Learned optimal soft error threshold                                       |
+| `sensor.smart_fan_controller_learned_hard_error`                      | °C    | Learned optimal hard error threshold                                       |
+| `sensor.smart_fan_controller_learned_limit_timeout`                   | min   | Learned base timeout stored in config                                      |
+| `sensor.smart_fan_controller_mpc_shadow_status`                       | —     | Shadow controller state (`Disabled`, `Ready`, etc.)                        |
+| `sensor.smart_fan_controller_mpc_shadow_reason`                       | —     | Explanation of the current shadow recommendation                           |
+| `sensor.smart_fan_controller_mpc_shadow_fan_mode`                     | —     | Fan mode the MPC shadow would choose                                       |
+| `sensor.smart_fan_controller_mpc_shadow_match`                        | —     | Whether the shadow recommendation matches the live heuristic               |
+| `sensor.smart_fan_controller_mpc_shadow_would_change_now`             | —     | Whether the shadow controller would actively change the fan right now      |
+| `sensor.smart_fan_controller_mpc_shadow_confidence`                   | %     | Confidence derived from learned profile coverage                           |
+| `sensor.smart_fan_controller_mpc_shadow_predicted_temperature_10_min` | °C    | Predicted temperature after 10 minutes with the recommended mode           |
+| `sensor.smart_fan_controller_mpc_shadow_predicted_temperature_30_min` | °C    | Predicted temperature after 30 minutes with the recommended mode           |
+| `sensor.smart_fan_controller_mpc_shadow_dead_time`                    | min   | Dead time currently used by the shadow simulator                           |
+| `sensor.smart_fan_controller_mpc_shadow_known_profiles`               | count | Number of reliable learned fan-mode profiles used by the shadow controller |
+| `sensor.smart_fan_controller_mpc_shadow_disturbance_bias`             | °C/h  | Learned disturbance correction currently applied by the shadow model       |
+
+See [docs/mpc_shadow_mode.md](docs/mpc_shadow_mode.md) for the full technical design of the learned model and MPC-lite shadow mode.
+
+### Defrost Diagnostic
+
+| Entity                               | Type   | Description                                                 |
+| ------------------------------------ | ------ | ----------------------------------------------------------- |
+| `sensor.smart_fan_controller_status` | Sensor | Shows `"Defrost hold: …"` when defrost protection is active |
 
 ---
 
@@ -244,7 +316,7 @@ This prevents window-open periods from corrupting the learned profiles.
 
 Manually apply the parameters computed by the learning system. Useful when auto-apply is disabled or to re-apply after a manual change.
 
-**Requirement**: `sensor.smart_fan_learning_status` must be `"Ready"`.
+**Requirement**: `sensor.smart_fan_controller_learning_status` must be `"Ready"`.
 
 ### `smart_fan_controller.reset_learning`
 
@@ -254,13 +326,15 @@ Clear all learning data and start fresh. Use after HVAC maintenance or a signifi
 
 ## Troubleshooting
 
-| Symptom                      | What to check / do                                                                                                                           |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Fan not changing**         | Check `sensor.smart_fan_status`. Check `sensor.smart_fan_minutes_since_last_change` — min interval or dead-time patience may be active.      |
-| **Too many fan changes**     | Increase `deadband` or `min_interval`. Enable learning to auto-optimize.                                                                     |
-| **Temperature overshoots**   | Decrease `deadband`. Verify Versatile Thermostat is providing an accurate slope.                                                             |
-| **Learning not progressing** | Verify `switch.smart_fan_learning_enabled` is on. Check HVAC is running and windows are closed.                                              |
-| **Auto-apply not working**   | Verify `sensor.smart_fan_learning_status` is `"Ready"` and learning is on. Auto-apply fires once — use `apply_learned_settings` to re-apply. |
+| Symptom                              | What to check / do                                                                                                                                                               |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fan not changing**                 | Check `sensor.smart_fan_controller_status`. Check `sensor.smart_fan_controller_fan_mode_last_change` — min interval or dead-time patience may be active.                         |
+| **Too many fan changes**             | Increase `deadband` or `min_interval`. Enable learning to auto-optimize.                                                                                                         |
+| **Temperature overshoots**           | Decrease `deadband`. Verify Versatile Thermostat is providing an accurate slope.                                                                                                 |
+| **Learning not progressing**         | Verify `switch.smart_fan_controller_learning_enabled` is on. Check HVAC is running and windows are closed.                                                                       |
+| **Auto-apply not working**           | Verify `sensor.smart_fan_controller_learning_status` is `"Ready"` and learning is on. Auto-apply fires once — use `apply_learned_settings` to re-apply.                          |
+| **Defrost triggering too often**     | If auto-detection fires spuriously (noisy slope), configure a physical defrost entity from your PAC integration. This replaces heuristic guesses with the actual defrost signal. |
+| **Step-down blocked during defrost** | Normal behavior — zones B and D are intentionally suspended during the 20 min defrost cooldown to avoid fan reduction while the PAC recovers.                                    |
 
 ---
 

--- a/custom_components/smart_fan_controller/__init__.py
+++ b/custom_components/smart_fan_controller/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
@@ -277,7 +278,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if not controller.is_defrost_active:
                     _LOGGER.info("External defrost entity %s reports active defrost", defrost_entity_id)
                 controller._defrost_active = True
-                controller._defrost_start_time = controller._now
+                controller._defrost_start_time = time.time()
 
         # HVAC idle detection: compressor not running (optional entities)
         is_hvac_idle = False

--- a/custom_components/smart_fan_controller/__init__.py
+++ b/custom_components/smart_fan_controller/__init__.py
@@ -1,33 +1,41 @@
 """Initialisation of Smart Fan Controller."""
+from __future__ import annotations
+
 import logging
 from datetime import timedelta
-from homeassistant.core import HomeAssistant
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.event import async_track_time_interval, async_track_state_change_event
-from homeassistant.helpers.storage import Store
 from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event, async_track_time_interval
+from homeassistant.helpers.storage import Store
 
 from .const import (
-    DOMAIN,
     CONF_CLIMATE_ENTITY,
-    CONF_DEADBAND,
-    CONF_MIN_INTERVAL,
-    CONF_SOFT_ERROR,
-    CONF_HARD_ERROR,
-    CONF_LIMIT_TIMEOUT,
-    CONF_LEARNING_ENABLED,
     CONF_DATA_COLLECTION,
+    CONF_DEADBAND,
+    CONF_DEFROST_ENTITY,
+    CONF_HARD_ERROR,
+    CONF_LEARNING_ENABLED,
+    CONF_LIMIT_TIMEOUT,
+    CONF_MIN_INTERVAL,
+    CONF_OPERATING_ENTITY,
+    CONF_SOFT_ERROR,
+    DEFAULT_DATA_COLLECTION,
     DEFAULT_DEADBAND,
+    DEFAULT_HARD_ERROR,
+    DEFAULT_LEARNING_ENABLED,
+    DEFAULT_LIMIT_TIMEOUT,
     DEFAULT_MIN_INTERVAL,
     DEFAULT_SOFT_ERROR,
-    DEFAULT_HARD_ERROR,
-    DEFAULT_LIMIT_TIMEOUT,
-    DEFAULT_LEARNING_ENABLED,
-    DEFAULT_DATA_COLLECTION,
     DELTA_TIME_CONTROL_LOOP,
-    STORAGE_VERSION,
-    STORAGE_KEY,
+    DOMAIN,
     LEARNING_DATA_SAVE_INTERVAL,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    build_unique_id,
+    extract_object_key_from_unique_id,
 )
 from .controller import SmartFanController
 from .data_collection import DataCollector
@@ -36,18 +44,105 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 
 
+def _filter_supported_fan_modes(raw_modes: list[str] | None) -> list[str]:
+    """Keep only supported manual fan modes."""
+    if not raw_modes:
+        return []
+    return [mode for mode in raw_modes if isinstance(mode, str) and mode.lower() not in {"auto", "off"}]
+
+
+def _extract_supported_fan_modes(state) -> list[str]:
+    """Extract supported fan modes from a climate state."""
+    if state is None:
+        return []
+    return _filter_supported_fan_modes(state.attributes.get("fan_modes"))
+
+
+async def _async_migrate_entity_registry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Migrate Smart Fan Controller entity IDs and unique IDs to the canonical naming."""
+    try:
+        entity_registry = er.async_get(hass)
+    except KeyError:
+        _LOGGER.debug(
+            "Skipping entity registry migration for %s because the registry is not initialized yet",
+            entry.entry_id,
+        )
+        return
+
+    if not hasattr(entity_registry, "entities"):
+        try:
+            await entity_registry.async_load()
+        except Exception as exc:  # pragma: no cover - defensive guard for partial test harnesses
+            _LOGGER.debug(
+                "Skipping entity registry migration for %s because the registry is not ready: %s",
+                entry.entry_id,
+                exc,
+            )
+            return
+
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    if not entries:
+        return
+
+    migrated = 0
+    reserved_entity_ids: set[str] = set()
+
+    for registry_entry in entries:
+        updates: dict[str, object] = {}
+        object_key = extract_object_key_from_unique_id(registry_entry.unique_id, entry.entry_id)
+
+        if object_key is None:
+            reserved_entity_ids.add(registry_entry.entity_id)
+            _LOGGER.warning(
+                "Skipping entity registry migration for %s because its unique_id is not recognized: %s",
+                registry_entry.entity_id,
+                registry_entry.unique_id,
+            )
+            continue
+
+        desired_unique_id = build_unique_id(object_key, entry.entry_id)
+        if registry_entry.unique_id != desired_unique_id:
+            updates["new_unique_id"] = desired_unique_id
+
+        desired_entity_id = entity_registry.async_get_available_entity_id(
+            registry_entry.domain,
+            f"{DOMAIN}_{object_key}",
+            current_entity_id=registry_entry.entity_id,
+            reserved_entity_ids=reserved_entity_ids,
+        )
+        reserved_entity_ids.add(desired_entity_id)
+
+        if registry_entry.entity_id != desired_entity_id:
+            updates["new_entity_id"] = desired_entity_id
+
+        if not registry_entry.has_entity_name:
+            updates["has_entity_name"] = True
+
+        if not updates:
+            continue
+
+        old_entity_id = registry_entry.entity_id
+        old_unique_id = registry_entry.unique_id
+        updated_entry = entity_registry.async_update_entity(registry_entry.entity_id, **updates)
+        migrated += 1
+        _LOGGER.info(
+            "Migrated entity %s -> %s (unique_id %s -> %s)",
+            old_entity_id,
+            updated_entry.entity_id,
+            old_unique_id,
+            updated_entry.unique_id,
+        )
+
+    if migrated:
+        _LOGGER.info("Entity registry migration completed for %s: %d entities updated", entry.entry_id, migrated)
+
+
 async def _apply_optimal_parameters(
     hass: HomeAssistant,
     entry: ConfigEntry,
     optimal: dict,
 ) -> None:
-    """Apply learned optimal parameters to the config entry and trigger a reload.
-
-    This is a standalone helper factorised from both the auto-apply block and the
-    apply_learned_settings service, so the logic lives in exactly one place.
-    Sets the learning_auto_applied flag in entry.data so that a subsequent reload
-    does not trigger a second auto-apply (breaking the infinite-reload loop).
-    """
+    """Apply learned optimal parameters to the config entry and trigger a reload."""
     new_data = {**entry.data}
     new_data["learning_auto_applied"] = True
     new_data[CONF_DEADBAND] = optimal["deadband"]
@@ -56,7 +151,8 @@ async def _apply_optimal_parameters(
     new_data[CONF_LIMIT_TIMEOUT] = optimal["limit_timeout"]
 
     _LOGGER.info(
-        "Applying learned settings: deadband=%.2f soft_error=%.2f hard_error=%.2f limit_timeout=%d",
+        "Applying learned settings for %s: deadband=%.2f soft_error=%.2f hard_error=%.2f limit_timeout=%d",
+        entry.entry_id,
         optimal["deadband"],
         optimal["soft_error"],
         optimal["hard_error"],
@@ -69,22 +165,43 @@ async def _apply_optimal_parameters(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the integration from a config entry."""
-    # 1. Retrieve settings from config entry (options override data)
     conf = {**entry.data, **entry.options}
     climate_id = conf[CONF_CLIMATE_ENTITY]
+    current_state = hass.states.get(climate_id)
+    initial_fan_modes = _extract_supported_fan_modes(current_state)
 
-    # Set up persistent storage for learning data
+    _LOGGER.info(
+        "Setting up Smart Fan Controller for %s (learning=%s, data_collection=%s)",
+        climate_id,
+        conf.get(CONF_LEARNING_ENABLED, DEFAULT_LEARNING_ENABLED),
+        conf.get(CONF_DATA_COLLECTION, DEFAULT_DATA_COLLECTION),
+    )
+
+    if initial_fan_modes:
+        _LOGGER.info("Initial fan modes discovered for %s: %s", climate_id, initial_fan_modes)
+    else:
+        _LOGGER.debug("No supported fan modes available yet for %s during setup", climate_id)
+
     store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}.{entry.entry_id}")
 
-    # Try to restore learning data from persistent storage first, then fall back to config entry
     learning_data = await store.async_load()
+    learning_data_source = "storage"
     if not learning_data:
         learning_data = entry.data.get("learning_data")
-        _LOGGER.debug("No persistent storage found, using config entry data")
+        learning_data_source = "config_entry"
+        _LOGGER.debug("No persistent storage found for %s, using config entry data", entry.entry_id)
 
-    # 2. Instantiate the controller with dynamic parameters from Config Flow
+    if learning_data:
+        _LOGGER.info(
+            "Restored learning data for %s from %s (%d slope samples, %d response events)",
+            entry.entry_id,
+            learning_data_source,
+            len(learning_data.get("slope_samples", [])),
+            len(learning_data.get("response_events", [])),
+        )
+
     controller = SmartFanController(
-        fan_modes=None,
+        fan_modes=initial_fan_modes or None,
         deadband=conf.get(CONF_DEADBAND, DEFAULT_DEADBAND),
         min_interval=conf.get(CONF_MIN_INTERVAL, DEFAULT_MIN_INTERVAL),
         soft_error=conf.get(CONF_SOFT_ERROR, DEFAULT_SOFT_ERROR),
@@ -94,48 +211,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         learning_enabled=conf.get(CONF_LEARNING_ENABLED, DEFAULT_LEARNING_ENABLED),
     )
 
-    # Instantiate the data collector (creates the CSV file immediately if enabled)
     data_collection_enabled = conf.get(CONF_DATA_COLLECTION, DEFAULT_DATA_COLLECTION)
     collector: DataCollector | None = (
-        DataCollector(hass.config.config_dir, entry.entry_id)
+        DataCollector(hass, hass.config.config_dir, entry.entry_id)
         if data_collection_enabled
         else None
     )
     if collector:
-        _LOGGER.info("DataCollector enabled – writing to %s", collector.path)
+        await collector.async_initialize()
+        _LOGGER.info("DataCollector enabled for %s, writing to %s", entry.entry_id, collector.path)
 
-    # 3. Store data for platforms and forward setup
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "controller": controller,
         "climate_entity": climate_id,
-        "sensor": None,  # Reference will be set in sensor.py
-        "store": store,  # Store the storage object for periodic saves
+        "sensors": [],
+        "ensure_profile_sensors": None,
+        "store": store,
     }
 
+    await _async_migrate_entity_registry(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    def _ensure_profile_sensors() -> None:
+        """Create late-discovered profile sensors when fan modes become available."""
+        add_profile_entities = hass.data[DOMAIN][entry.entry_id].get("ensure_profile_sensors")
+        if callable(add_profile_entities):
+            add_profile_entities()
 
     async def run_control_loop(_):
         """Main control loop executed every 2 minutes."""
         current_state = hass.states.get(climate_id)
 
-        # Guard clause if the climate entity is still missing from the state machine
         if not current_state:
-            _LOGGER.warning("Climate entity %s not found", climate_id)
+            _LOGGER.warning("Climate entity %s not found; skipping control cycle", climate_id)
             return
 
-        # Dynamically fetch fan modes if the controller doesn't have them yet
-        # Check for both None and empty list to handle race condition at startup
         if not controller.fan_modes:
-            raw_modes = current_state.attributes.get("fan_modes", [])
-            # Remove "auto" from the list of modes
-            filtered_modes = [m for m in raw_modes if m.lower() not in ["auto", "off"]]
-            if filtered_modes:
-                controller.fan_modes = filtered_modes
-                _LOGGER.info("Detected fan modes for %s: %s", climate_id, controller.fan_modes)
+            detected_modes = _extract_supported_fan_modes(current_state)
+            if detected_modes:
+                controller.fan_modes = detected_modes
+                _LOGGER.info("Detected fan modes for %s during runtime: %s", climate_id, detected_modes)
+                _ensure_profile_sensors()
             else:
-                _LOGGER.debug("Climate entity %s has no valid fan modes yet, will retry on next cycle", climate_id)
+                _LOGGER.debug("Climate entity %s has no supported fan modes yet, will retry next cycle", climate_id)
 
-        # Extract VTherm and Climate data
         attrs = current_state.attributes
         vtherm_slope = attrs.get("specific_states", {}).get("temperature_slope", 0)
         current_temp = attrs.get("current_temperature")
@@ -143,32 +262,55 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hvac_mode = attrs.get("hvac_mode")
         current_fan = attrs.get("fan_mode")
 
-        # Detect window-open state from VTherm attributes
-        # VTherm exposes window_manager.window_state ("on"/"off") and
-        # hvac_off_reason ("Window" when heating is cut due to open window)
         window_mgr = attrs.get("window_manager", {})
         is_window_open = (
-            window_mgr.get("window_state") == "on" or window_mgr.get("window_auto_state") == "on" or attrs.get("specific_states", {}).get("hvac_off_reason") == "Window"
+            window_mgr.get("window_state") == "on"
+            or window_mgr.get("window_auto_state") == "on"
+            or attrs.get("specific_states", {}).get("hvac_off_reason") == "Window"
         )
 
+        # External defrost entity (optional): force defrost state when the PAC reports it
+        defrost_entity_id = conf.get(CONF_DEFROST_ENTITY)
+        if defrost_entity_id:
+            defrost_state = hass.states.get(defrost_entity_id)
+            if defrost_state and defrost_state.state in ("on", "true", "True", "1"):
+                if not controller.is_defrost_active:
+                    _LOGGER.info("External defrost entity %s reports active defrost", defrost_entity_id)
+                controller._defrost_active = True
+                controller._defrost_start_time = controller._now
+
+        # HVAC idle detection: compressor not running (optional entities)
+        is_hvac_idle = False
+        operating_entity_id = conf.get(CONF_OPERATING_ENTITY)
+        if operating_entity_id:
+            operating_state = hass.states.get(operating_entity_id)
+            if operating_state and operating_state.state in ("off", "false", "False", "0"):
+                is_hvac_idle = True
+
         if vtherm_slope is None:
-            _LOGGER.warning("%s missing VTherm temperature_slope; skipping control cycle", climate_id)
+            _LOGGER.warning("%s is missing VTherm temperature_slope; skipping control cycle", climate_id)
             return
 
         if current_temp is None or target_temp is None:
-            _LOGGER.debug("Incomplete temperature data for %s, skipping cycle", climate_id)
+            _LOGGER.debug(
+                "Skipping control cycle for %s because temperature data is incomplete (current=%s, target=%s)",
+                climate_id,
+                current_temp,
+                target_temp,
+            )
             return
 
         _LOGGER.debug(
-            "Cycle: temp=%.2f target=%.2f slope=%.3f fan=%s hvac=%s",
+            "Cycle start for %s: temp=%.2f target=%.2f slope=%.3f fan=%s hvac=%s window_open=%s",
+            climate_id,
             current_temp,
             target_temp,
             vtherm_slope,
             current_fan,
             hvac_mode,
+            is_window_open,
         )
 
-        # Execute decision logic
         decision = controller.calculate_decision(
             float(current_temp),
             float(target_temp),
@@ -176,13 +318,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             str(hvac_mode),
             current_fan,
             is_window_open,
+            is_hvac_idle,
         )
 
-        # Persist one CSV row for offline analysis (beta instrumentation)
+        _LOGGER.debug(
+            "Cycle result for %s: live=%s reason=%s",
+            climate_id,
+            decision.get("fan_mode"),
+            decision.get("reason"),
+        )
+
         if collector:
             effective_slope = -float(vtherm_slope) if str(hvac_mode) == "cool" else float(vtherm_slope)
             minutes_since = decision.get("minutes_since_last_change", 0.0)
-            collector.record(
+            await collector.async_record(
                 hvac_mode=str(hvac_mode),
                 current_temp=float(current_temp),
                 target_temp=float(target_temp),
@@ -195,42 +344,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 force=decision.get("reason", "").startswith(("Emergency", "Setpoint drop")),
                 learning_ready=controller.learning_enabled and controller.learning.is_ready(),
                 dead_time=controller.learning.get_dead_time() if controller.learning_enabled else 0.0,
+                defrost_active=controller.is_defrost_active,
+                is_hvac_idle=is_hvac_idle,
             )
 
-        # Update all sensors stored in the list
         sensors = hass.data[DOMAIN][entry.entry_id].get("sensors")
         if sensors:
-            _LOGGER.debug("Updating %s diagnostic sensors", len(sensors))
+            _LOGGER.debug("Updating %d Smart Fan Controller sensors for %s", len(sensors), climate_id)
             for sensor in sensors:
-                if hasattr(sensor, 'update_from_controller'):
+                if hasattr(sensor, "update_from_controller"):
                     sensor.update_from_controller(decision)
-                # Force update all sensors (including learning sensors)
                 sensor.async_write_ha_state()
 
-        # Auto-apply learned parameters when learning becomes ready (only once per installation).
-        # The flag is persisted in entry.data so it survives reloads and avoids an infinite loop
-        # where the reload itself triggers another auto-apply.
-        if controller.learning_enabled and controller.learning.is_ready() and not entry.data.get("learning_auto_applied", False):
-
+        if (
+            controller.learning_enabled
+            and controller.learning.is_ready()
+            and not entry.data.get("learning_auto_applied", False)
+        ):
             optimal = controller.learning.compute_optimal_parameters()
             if optimal:
-                _LOGGER.info("Learning is ready! Scheduling auto-apply of learned parameters.")
+                _LOGGER.info("Learning is ready for %s, scheduling auto-apply of learned parameters", climate_id)
                 hass.async_create_task(_apply_optimal_parameters(hass, entry, optimal))
 
-        # Apply the new fan speed if a change is required
         if decision["fan_mode"] != current_fan:
             _LOGGER.info(
-                "Changing %s fan to %s. Reason: %s",
-                climate_id, decision["fan_mode"], decision["reason"]
+                "Changing %s fan mode from %s to %s (%s)",
+                climate_id,
+                current_fan,
+                decision["fan_mode"],
+                decision["reason"],
             )
-            await hass.services.async_call("climate", "set_fan_mode", {
-                "entity_id": climate_id,
-                "fan_mode": decision["fan_mode"]
-            })
-            # Advance the cooldown timer only after the service call succeeds
+            await hass.services.async_call(
+                "climate",
+                "set_fan_mode",
+                {"entity_id": climate_id, "fan_mode": decision["fan_mode"]},
+            )
             controller.confirm_fan_change()
+        else:
+            _LOGGER.debug("No fan mode change required for %s (%s)", climate_id, decision["reason"])
 
     async def _handle_manual_change(event):
+        """Track manual fan mode changes to reset the controller cooldown."""
         new_state = event.data.get("new_state")
         old_state = event.data.get("old_state")
         if not new_state or not old_state:
@@ -239,107 +393,107 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_fan = new_state.attributes.get("fan_mode")
         old_fan = old_state.attributes.get("fan_mode")
 
-        # Ignore transitions where the fan mode disappears (entity going unavailable)
         if new_fan is None or new_fan == old_fan:
             return
 
-        _LOGGER.info("Manual fan_mode change detected, resetting timer")
+        _LOGGER.info("Manual fan mode change detected for %s: %s -> %s", climate_id, old_fan, new_fan)
 
-        # Reset internal controller timer
         manual_data = controller.record_manual_override(new_fan)
 
-        # Instantly refresh sensors to show the change
         sensors = hass.data[DOMAIN][entry.entry_id].get("sensors", [])
         for sensor in sensors:
             if hasattr(sensor, "update_from_controller"):
                 sensor.update_from_controller(manual_data)
-            else:
-                # Learning sensor updates itself via properties
-                sensor.async_write_ha_state()
+            sensor.async_write_ha_state()
 
-    # Schedule the loop and run it immediately once to initialize
     remove_timer = async_track_time_interval(hass, run_control_loop, timedelta(minutes=DELTA_TIME_CONTROL_LOOP))
     manual_change = async_track_state_change_event(hass, [climate_id], _handle_manual_change)
-    # This ensures the timer stops if the integration is unloaded/removed
     entry.async_on_unload(remove_timer)
     entry.async_on_unload(manual_change)
 
-    # Trigger first run immediately after setup
     hass.async_create_task(run_control_loop(None))
 
     async def periodic_save_learning(_):
         """Periodically save learning data to persistent storage."""
-        learning_data = controller.learning.to_dict()
-        await store.async_save(learning_data)
-        _LOGGER.debug("Learning data saved to persistent storage")
+        learning_data_to_save = controller.learning.to_dict()
+        await store.async_save(learning_data_to_save)
+        _LOGGER.debug(
+            "Persisted learning data for %s (%d slope samples, %d response events)",
+            entry.entry_id,
+            len(learning_data_to_save.get("slope_samples", [])),
+            len(learning_data_to_save.get("response_events", [])),
+        )
 
-    # Schedule periodic saves every 5 minutes
-    remove_periodic_save = async_track_time_interval(
-        hass, periodic_save_learning, LEARNING_DATA_SAVE_INTERVAL
-    )
+    remove_periodic_save = async_track_time_interval(hass, periodic_save_learning, LEARNING_DATA_SAVE_INTERVAL)
     entry.async_on_unload(remove_periodic_save)
 
-    # Register service to apply learned parameters
     async def apply_learned_settings(_):
         """Service to apply optimal parameters from learning."""
         if not controller.learning.is_ready():
-            _LOGGER.warning("Learning not complete yet (%.1f%%), cannot apply settings", controller.learning.get_progress())
+            _LOGGER.warning(
+                "Learning not complete yet for %s (%.1f%%), cannot apply settings",
+                climate_id,
+                controller.learning.get_progress(),
+            )
             return
 
         optimal = controller.learning.compute_optimal_parameters()
         if not optimal:
-            _LOGGER.error("Failed to compute optimal parameters")
+            _LOGGER.error("Failed to compute optimal parameters for %s", climate_id)
             return
 
         await _apply_optimal_parameters(hass, entry, optimal)
 
     hass.services.async_register(DOMAIN, "apply_learned_settings", apply_learned_settings)
 
-    # Register service to reset learning data
     async def reset_learning(_):
         """Service to clear all learning data and restart learning."""
         controller.learning.reset()
 
-        # Persist cleared data to both config entry and storage
-        learning_data = controller.learning.to_dict()
-        new_data = {**entry.data, "learning_data": learning_data}
+        learning_data_to_save = controller.learning.to_dict()
+        new_data = {**entry.data, "learning_data": learning_data_to_save}
         hass.config_entries.async_update_entry(entry, data=new_data)
-        await store.async_save(learning_data)
+        await store.async_save(learning_data_to_save)
 
-        # Refresh sensors immediately
         sensors = hass.data[DOMAIN][entry.entry_id].get("sensors", [])
         for sensor in sensors:
             sensor.async_write_ha_state()
 
-        _LOGGER.info("Learning reset: all samples and stats cleared")
+        _LOGGER.info("Learning reset for %s: all samples and stats cleared", climate_id)
 
     hass.services.async_register(DOMAIN, "reset_learning", reset_learning)
 
     return True
 
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry when it's being removed."""
-    # Save learning data before unloading
     entry_data = hass.data[DOMAIN].get(entry.entry_id)
     if entry_data:
         controller = entry_data.get("controller")
         store = entry_data.get("store")
-        if controller and hasattr(controller, 'learning'):
+        if controller and hasattr(controller, "learning"):
             learning_data = controller.learning.to_dict()
-            # Store in both config entry and persistent storage
             new_data = {**entry.data, "learning_data": learning_data}
             hass.config_entries.async_update_entry(entry, data=new_data)
             if store:
                 await store.async_save(learning_data)
-                _LOGGER.debug("Learning data saved on unload")
+                _LOGGER.debug(
+                    "Learning data saved on unload for %s (%d slope samples, %d response events)",
+                    entry.entry_id,
+                    len(learning_data.get("slope_samples", [])),
+                    len(learning_data.get("response_events", [])),
+                )
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        _LOGGER.info("Unloaded Smart Fan Controller entry %s", entry.entry_id)
     return unload_ok
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
+    _LOGGER.info("Reloading Smart Fan Controller entry %s", entry.entry_id)
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)

--- a/custom_components/smart_fan_controller/__init__.py
+++ b/custom_components/smart_fan_controller/__init__.py
@@ -375,12 +375,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 decision["fan_mode"],
                 decision["reason"],
             )
-            await hass.services.async_call(
-                "climate",
-                "set_fan_mode",
-                {"entity_id": climate_id, "fan_mode": decision["fan_mode"]},
-            )
-            controller.confirm_fan_change()
+            try:
+                await hass.services.async_call(
+                    "climate",
+                    "set_fan_mode",
+                    {"entity_id": climate_id, "fan_mode": decision["fan_mode"]},
+                    blocking=True,
+                )
+                controller.confirm_fan_change()
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(
+                    "Failed to set fan mode %s on %s; cooldown not advanced",
+                    decision["fan_mode"],
+                    climate_id,
+                )
         else:
             _LOGGER.debug("No fan mode change required for %s (%s)", climate_id, decision["reason"])
 

--- a/custom_components/smart_fan_controller/config_flow.py
+++ b/custom_components/smart_fan_controller/config_flow.py
@@ -17,6 +17,8 @@ from .const import (
     CONF_LIMIT_TIMEOUT,
     CONF_LEARNING_ENABLED,
     CONF_DATA_COLLECTION,
+    CONF_DEFROST_ENTITY,
+    CONF_OPERATING_ENTITY,
     DEFAULT_DEADBAND,
     DEFAULT_MIN_INTERVAL,
     DEFAULT_SOFT_ERROR,
@@ -117,6 +119,8 @@ class SmartFanControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 vol.Optional(CONF_LEARNING_ENABLED, default=DEFAULT_LEARNING_ENABLED): selector.BooleanSelector(),
                 vol.Optional(CONF_DATA_COLLECTION, default=DEFAULT_DATA_COLLECTION): selector.BooleanSelector(),
+                vol.Optional(CONF_DEFROST_ENTITY): selector.EntitySelector(selector.EntitySelectorConfig(domain=["binary_sensor", "sensor", "input_boolean"])),
+                vol.Optional(CONF_OPERATING_ENTITY): selector.EntitySelector(selector.EntitySelectorConfig(domain=["binary_sensor", "sensor", "input_boolean"])),
             }
         )
 
@@ -191,6 +195,8 @@ class SmartFanControllerOptionsFlow(config_entries.OptionsFlow):
                 ),
                 vol.Optional(CONF_LEARNING_ENABLED, default=current_data.get(CONF_LEARNING_ENABLED, DEFAULT_LEARNING_ENABLED)): selector.BooleanSelector(),
                 vol.Optional(CONF_DATA_COLLECTION, default=current_data.get(CONF_DATA_COLLECTION, DEFAULT_DATA_COLLECTION)): selector.BooleanSelector(),
+                vol.Optional(CONF_DEFROST_ENTITY, default=current_data.get(CONF_DEFROST_ENTITY, vol.UNDEFINED)): selector.EntitySelector(selector.EntitySelectorConfig(domain=["binary_sensor", "sensor", "input_boolean"])),
+                vol.Optional(CONF_OPERATING_ENTITY, default=current_data.get(CONF_OPERATING_ENTITY, vol.UNDEFINED)): selector.EntitySelector(selector.EntitySelectorConfig(domain=["binary_sensor", "sensor", "input_boolean"])),
             }
         )
 

--- a/custom_components/smart_fan_controller/const.py
+++ b/custom_components/smart_fan_controller/const.py
@@ -2,6 +2,11 @@
 from datetime import timedelta
 
 DOMAIN = "smart_fan_controller"
+DEVICE_NAME = "Smart Fan Controller"
+LEGACY_UNIQUE_ID_PREFIX = "smart_fan"
+ENTITY_UNIQUE_ID_PREFIX = DOMAIN
+EFFECTIVE_SLOPE_UNIT = "°C/h"
+PROFILE_HVAC_MODES = ("heat", "cool")
 
 CONF_CLIMATE_ENTITY = "climate_entity"
 CONF_DEADBAND = "deadband"
@@ -11,6 +16,8 @@ CONF_HARD_ERROR = "hard_error"
 CONF_LIMIT_TIMEOUT = "limit_timeout"
 CONF_LEARNING_ENABLED = "learning_enabled"
 CONF_DATA_COLLECTION = "data_collection"
+CONF_DEFROST_ENTITY = "defrost_entity"
+CONF_OPERATING_ENTITY = "operating_entity"
 
 # Default values
 DEFAULT_DEADBAND = 0.2
@@ -44,3 +51,48 @@ PHASE_ESTABLISHED = "ESTABLISHED"
 MIN_SAMPLES_LEARNING = 240  # Minimum slope samples required for initial readiness
 MIN_LIMIT_TIMEOUT = 5  # Minimum limit_timeout (minutes) derived from learning
 MIN_MODE_PROFILE_SAMPLES = 10  # Minimum samples per fan mode to consider profile reliable
+
+LEGACY_OBJECT_KEY_MAP = {
+    "reason": "status",
+    "fan_mode": "fan_mode",
+    "minutes_since_last_change": "fan_mode_last_change",
+    "projected_temperature": "temperature_projected_10_min",
+    "projected_temperature_error": "temperature_projected_error_10_min",
+    "temperature_error": "temperature_error",
+    "learning_progress": "learning_progress",
+    "learning_status": "learning_status",
+    "learning_samples": "learning_samples",
+    "learning_response_events": "learning_response_events",
+    "learned_dead_time": "learned_dead_time",
+    "effective_timeout": "effective_timeout",
+    "deadband": "learned_deadband",
+    "soft_error": "learned_soft_error",
+    "hard_error": "learned_hard_error",
+    "limit_timeout": "learned_limit_timeout",
+    "learning_enabled": "learning_enabled",
+}
+
+
+def build_unique_id(object_key: str, entry_id: str) -> str:
+    """Build the canonical unique_id for an entity."""
+    return f"{ENTITY_UNIQUE_ID_PREFIX}_{object_key}_{entry_id}"
+
+
+def build_entity_id(platform_domain: str, object_key: str) -> str:
+    """Build the canonical entity_id suggestion for an entity."""
+    return f"{platform_domain}.{DOMAIN}_{object_key}"
+
+
+def extract_object_key_from_unique_id(unique_id: str, entry_id: str) -> str | None:
+    """Extract the logical object key from either a legacy or canonical unique_id."""
+    suffix = f"_{entry_id}"
+    if not unique_id.endswith(suffix):
+        return None
+
+    stem = unique_id[: -len(suffix)]
+    for prefix in (f"{ENTITY_UNIQUE_ID_PREFIX}_", f"{LEGACY_UNIQUE_ID_PREFIX}_"):
+        if stem.startswith(prefix):
+            raw_key = stem[len(prefix):]
+            return LEGACY_OBJECT_KEY_MAP.get(raw_key, raw_key)
+
+    return None

--- a/custom_components/smart_fan_controller/controller.py
+++ b/custom_components/smart_fan_controller/controller.py
@@ -55,6 +55,11 @@ class SmartFanController:
         self._last_slope_significant_change: float = self._now
         self._last_hvac_mode: str | None = None
 
+        # Defrost state (set externally via CONF_DEFROST_ENTITY; 20-min cooldown applied by __init__.py)
+        self._defrost_active: bool = False
+        self._defrost_start_time: float = 0.0
+        self._defrost_cooldown_minutes: float = 20.0
+
         # Learning system
         self.learning_enabled = learning_enabled
         if learning_data:
@@ -110,6 +115,18 @@ class SmartFanController:
         return self._limit_timeout
 
     @property
+    def is_defrost_active(self) -> bool:
+        """Return whether defrost (or its cooldown) is currently active."""
+        if not self._defrost_active:
+            return False
+        elapsed = (self._now - self._defrost_start_time) / 60.0
+        if elapsed > self._defrost_cooldown_minutes:
+            self._defrost_active = False
+            _LOGGER.debug("Defrost cooldown expired after %.1f min", elapsed)
+            return False
+        return True
+
+    @property
     def _projected_error_threshold(self) -> float:
         """Calculate projected error threshold as midpoint between soft and hard error."""
         return (self._soft_error + self._hard_error) / 2
@@ -155,16 +172,23 @@ class SmartFanController:
             return PHASE_TRANSIENT
         return PHASE_ESTABLISHED
 
-    def _apply_step_limit(self, current_index: int, new_index: int) -> int:
+    def _apply_step_limit(self, current_index: int, new_index: int, current_error: float = 0.0) -> int:
         """
         Ensure the fan speed decreases by no more than one step at a time
         to maintain system stability.
+        Allow +2 step-up when error exceeds soft_error for faster recovery.
         """
         if (new_index - current_index) < -1:
             return current_index - 1
+        if (new_index - current_index) > 2:
+            if current_error > self._soft_error:
+                return current_index + 2
+            return current_index + 1
+        if (new_index - current_index) == 2 and current_error <= self._soft_error:
+            return current_index + 1
         return new_index
 
-    def determine_final_index(self, current_index: int, new_index: int, minutes_since_change: float, force: bool) -> int:
+    def determine_final_index(self, current_index: int, new_index: int, minutes_since_change: float, force: bool, current_error: float = 0.0) -> int:
         """Limit fan speed changes with safety guards."""
         if force:
             # Emergency and setpoint-drop bypass all guards (timer + step limit).
@@ -175,11 +199,12 @@ class SmartFanController:
         if minutes_since_change < self._min_interval:
             return current_index
 
-        return self._apply_step_limit(current_index, new_index)
+        return self._apply_step_limit(current_index, new_index, current_error)
 
     def record_manual_override(self, new_fan: str) -> dict:
         """Persist last change timestamp and return manual override payload."""
         self._last_change_time = time.time()
+        _LOGGER.debug("Manual override recorded: fan=%s at %.3f", new_fan, self._last_change_time)
 
         return {
             "fan_mode": new_fan,
@@ -196,6 +221,7 @@ class SmartFanController:
         the method compatible with tests that set self._now directly.
         """
         self._last_change_time = self._now
+        _LOGGER.debug("Confirmed fan change at %.3f", self._last_change_time)
 
     def save_states(
         self,
@@ -205,6 +231,8 @@ class SmartFanController:
         effective_slope: float,
         slope_change: bool,
         is_window_open: bool = False,
+        is_defrost_active: bool = False,
+        is_hvac_idle: bool = False,
     ):
         """Update controller state and learn response times when conditions are clean."""
         if target_fan != current_fan:
@@ -212,6 +240,12 @@ class SmartFanController:
             # Note: _last_change_time is updated by confirm_fan_change() AFTER the
             # HA service call succeeds, to avoid advancing the cooldown on failed calls.
             self._slope_at_last_change = effective_slope
+            _LOGGER.debug(
+                "Pending fan change snapshot saved: %s -> %s with effective_slope=%.3f",
+                current_fan,
+                target_fan,
+                effective_slope,
+            )
 
         if target_fan != current_fan or slope_change:
             self._previous_slope = vtherm_slope
@@ -222,17 +256,33 @@ class SmartFanController:
             response_time = (self._now - self._last_change_time) / 60
             # Only record reasonable response times (between 2 and 60 minutes)
             # Very short times might be noise, very long times might be system off or other issues
-            if 2.0 <= response_time <= 60.0 and self.learning_enabled and not is_window_open:
+            if 2.0 <= response_time <= 60.0 and self.learning_enabled and not is_window_open and not is_defrost_active and not is_hvac_idle:
                 self.learning.add_response_event(response_time)
+                _LOGGER.debug(
+                    "Recorded thermal response event: %.1f min after last fan change",
+                    response_time,
+                )
+            else:
+                _LOGGER.debug(
+                    "Ignored thermal response event: response_time=%.1f learning_enabled=%s window_open=%s defrost=%s hvac_idle=%s",
+                    response_time,
+                    self.learning_enabled,
+                    is_window_open,
+                    is_defrost_active,
+                    is_hvac_idle,
+                )
             # Track when the last slope change occurred (for reference, not used in calculation)
             self._last_slope_significant_change = self._now
 
-    def calculate_decision(self, current_temp: float, target_temp: float, vtherm_slope: float, hvac_mode: str, current_fan: str | None, is_window_open: bool = False) -> dict:
+    def calculate_decision(
+        self, current_temp: float, target_temp: float, vtherm_slope: float, hvac_mode: str, current_fan: str | None, is_window_open: bool = False, is_hvac_idle: bool = False
+    ) -> dict:
         """Compute new fan speed."""
         self._now = time.time()
 
         # Early exit: unsupported or inactive HVAC modes
         if hvac_mode in ("off", "dry", "fan_only"):
+            _LOGGER.debug("Skipping active control because HVAC mode is %s", hvac_mode)
             return {
                 "fan_mode": current_fan,
                 "projected_temperature": round(current_temp, 2),
@@ -305,6 +355,8 @@ class SmartFanController:
         force = False
         reason = "Unknown"
 
+        defrost_protection = self.is_defrost_active
+
         # A. EMERGENCY (High real-time error) => highest fan speed immediatly
         if current_temperature_error >= self._hard_error:
             new_index = max_index
@@ -320,17 +372,22 @@ class SmartFanController:
 
         # B. BRAKING ANTICIPATION (Overshoot predicted)
         elif projected_temperature_error < -self._deadband and slope_change:
-            new_index = max(0, current_index - 1)
-            reason = f"Braking: Target overshoot predicted ({round(projected_temperature, 2)}°C)"
+            if defrost_protection and current_temperature_error > 0:
+                reason = "Defrost hold: blocking braking during defrost recovery"
+            else:
+                new_index = max(0, current_index - 1)
+                reason = f"Braking: Target overshoot predicted ({round(projected_temperature, 2)}°C)"
 
         # C. RECOVERY ANTICIPATION (Under-target predicted)
         elif above_soft_error:
-            if phase == PHASE_DEAD_TIME:
+            if is_hvac_idle:
+                reason = "HVAC idle: compressor off, holding current speed"
+            elif phase == PHASE_DEAD_TIME:
                 reason = "Patience: Waiting for thermal response"
-            elif is_slope_improving:
+            elif is_slope_improving and projected_temperature_error <= 0:
                 reason = "Patience: Trend is improving"
             elif min_interval_expired:
-                new_index = min(max_index, current_index + 1)
+                new_index = min(max_index, current_index + 2) if current_temperature_error > self._hard_error * 0.75 else min(max_index, current_index + 1)
                 intensity = "Strong" if projected_temperature_error > self._projected_error_threshold else "Soft"
                 reason = f"{intensity} recovery: Drop predicted to {round(projected_temperature, 2)}°C"
             else:
@@ -338,9 +395,13 @@ class SmartFanController:
 
         # D. DRIFT IN COMFORT ZONE
         elif current_temperature_error > 0:
+            if is_hvac_idle:
+                reason = "HVAC idle: compressor off, holding current speed"
             # Descent: strong favorable slope in established phase → reduce only when close enough to target
-            if effective_slope > THRESHOLD_SLOPE * 2 and phase == PHASE_ESTABLISHED and interval_expired:
-                if can_reduce_on_favorable_slope:
+            elif effective_slope > THRESHOLD_SLOPE * 2 and phase == PHASE_ESTABLISHED and interval_expired:
+                if defrost_protection:
+                    reason = "Defrost hold: blocking speed reduction during defrost recovery"
+                elif can_reduce_on_favorable_slope:
                     new_index = max(0, current_index - 1)
                     reason = "Maintenance: Strong favorable slope, reducing"
                 else:
@@ -371,7 +432,7 @@ class SmartFanController:
                 reason = "Comfort: Stable"
 
         # FINAL GUARDS & STEP-DOWN
-        final_index = self.determine_final_index(current_index, new_index, minutes_since_change, force)
+        final_index = self.determine_final_index(current_index, new_index, minutes_since_change, force, current_temperature_error)
         target_fan = self._fan_modes[final_index]
 
         # Update memory
@@ -382,15 +443,23 @@ class SmartFanController:
             effective_slope,
             slope_change,
             is_window_open,
+            defrost_protection,
+            is_hvac_idle,
         )
 
         # Collect learning data using the fan mode CURRENTLY active (not the decided one),
         # so the slope observation is correctly attributed to the mode that produced it.
-        if self.learning_enabled and current_fan is not None and current_fan in self._fan_modes:
+        # Skip during defrost and HVAC idle: the slope is distorted and would corrupt learned profiles.
+        if self.learning_enabled and current_fan is not None and current_fan in self._fan_modes and not defrost_protection and not is_hvac_idle:
             self.learning.add_slope_sample(current_fan, vtherm_slope, current_temperature_error, hvac_mode, is_window_open)
 
         _LOGGER.debug(
-            "Decision: hvac=%s current=%.2f target=%.2f err=%.2f proj=%.2f proj_err=%.2f slope=%.3f eff_slope=%.3f phase=%s minutes=%.1f -> %s (%s)",
+            (
+                "Decision: hvac=%s current=%.2f target=%.2f err=%.2f proj=%.2f proj_err=%.2f "
+                "slope=%.3f eff_slope=%.3f phase=%s minutes=%.1f timeout=%.1f "
+                "slope_change=%s improving=%s interval_expired=%s min_interval_expired=%s "
+                "window_open=%s defrost=%s hvac_idle=%s idx=%d->%d->%d force=%s -> %s (%s)"
+            ),
             hvac_mode,
             current_temp,
             target_temp,
@@ -401,6 +470,18 @@ class SmartFanController:
             effective_slope,
             phase,
             minutes_since_change,
+            effective_timeout,
+            slope_change,
+            is_slope_improving,
+            interval_expired,
+            min_interval_expired,
+            is_window_open,
+            defrost_protection,
+            is_hvac_idle,
+            current_index,
+            new_index,
+            final_index,
+            force,
             target_fan,
             reason,
         )
@@ -411,5 +492,7 @@ class SmartFanController:
             "projected_temperature_error": round(projected_temperature_error, 2),
             "temperature_error": round(current_temperature_error, 2),
             "minutes_since_last_change": round(minutes_since_change, 1),
-            "reason": reason
+            "reason": reason,
+            "defrost_active": defrost_protection,
+            "hvac_idle": is_hvac_idle,
         }

--- a/custom_components/smart_fan_controller/data_collection.py
+++ b/custom_components/smart_fan_controller/data_collection.py
@@ -7,17 +7,21 @@ CSV columns (in order):
   timestamp, hvac_mode, current_temp, target_temp, current_error,
   vtherm_slope, effective_slope, projected_temp, projected_error,
   phase, minutes_since_change, effective_timeout, current_fan, decided_fan,
-  force, reason, learning_ready, dead_time, is_window_open
+  force, reason, learning_ready, dead_time, is_window_open,
+  defrost_active, hvac_idle
 """
 
+import asyncio
 import csv
 import logging
 import os
 from datetime import datetime, timezone
 
+from homeassistant.core import HomeAssistant
+
 _LOGGER = logging.getLogger(__name__)
 
-# Header used when creating a new file.  Keep in sync with _row() below.
+# Header used when creating a new file. Keep in sync with async_record() below.
 _HEADER = [
     "timestamp",
     "hvac_mode",
@@ -38,25 +42,29 @@ _HEADER = [
     "learning_ready",
     "dead_time",
     "is_window_open",
+    "defrost_active",
+    "hvac_idle",
 ]
 
-# Rotate the file when it exceeds this size (bytes).  10 MB keeps ~200 000 rows.
+# Rotate the file when it exceeds this size (bytes). 10 MB keeps ~200 000 rows.
 _MAX_FILE_SIZE = 10 * 1024 * 1024
 
 
 class DataCollector:
     """Appends one CSV row per control cycle to a rotating log file."""
 
-    def __init__(self, config_dir: str, entry_id: str) -> None:
+    def __init__(self, hass: HomeAssistant, config_dir: str, entry_id: str) -> None:
+        self._hass = hass
         self._path = os.path.join(config_dir, f"smart_fan_controller_data_{entry_id[:8]}.csv")
         self._rotated_path = self._path.replace(".csv", "_old.csv")
-        self._ensure_header()
+        self._io_lock = asyncio.Lock()
 
-    # ------------------------------------------------------------------
-    # Public interface
-    # ------------------------------------------------------------------
+    async def async_initialize(self) -> None:
+        """Create or validate the CSV file outside the event loop."""
+        async with self._io_lock:
+            await self._hass.async_add_executor_job(self._ensure_header)
 
-    def record(
+    async def async_record(
         self,
         *,
         hvac_mode: str,
@@ -71,8 +79,10 @@ class DataCollector:
         force: bool,
         learning_ready: bool,
         dead_time: float,
+        defrost_active: bool = False,
+        is_hvac_idle: bool = False,
     ) -> None:
-        """Append one row to the CSV file."""
+        """Append one row to the CSV file outside the event loop."""
         row = [
             datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             hvac_mode,
@@ -93,25 +103,29 @@ class DataCollector:
             int(learning_ready),
             round(dead_time, 2),
             int(is_window_open),
+            int(defrost_active),
+            int(is_hvac_idle),
         ]
-        try:
-            self._rotate_if_needed()
-            with open(self._path, "a", newline="", encoding="utf-8") as fh:
-                csv.writer(fh).writerow(row)
-        except OSError as exc:
-            _LOGGER.warning("DataCollector: could not write to %s: %s", self._path, exc)
+        async with self._io_lock:
+            await self._hass.async_add_executor_job(self._write_row, row)
 
     @property
     def path(self) -> str:
         """Return the active CSV file path."""
         return self._path
 
-    # ------------------------------------------------------------------
-    # Private helpers
-    # ------------------------------------------------------------------
+    def _write_row(self, row: list[object]) -> None:
+        """Write one row to disk, rotating the file first if needed."""
+        try:
+            self._rotate_if_needed()
+            self._ensure_header()
+            with open(self._path, "a", newline="", encoding="utf-8") as fh:
+                csv.writer(fh).writerow(row)
+        except OSError as exc:
+            _LOGGER.warning("DataCollector: could not write to %s: %s", self._path, exc)
 
     def _ensure_header(self) -> None:
-        """Write the header row if the file does not exist yet."""
+        """Write the header row if missing, or rotate when the schema changes."""
         if not os.path.exists(self._path):
             try:
                 with open(self._path, "w", newline="", encoding="utf-8") as fh:
@@ -119,6 +133,20 @@ class DataCollector:
                 _LOGGER.info("DataCollector: created %s", self._path)
             except OSError as exc:
                 _LOGGER.warning("DataCollector: could not create %s: %s", self._path, exc)
+            return
+
+        try:
+            with open(self._path, newline="", encoding="utf-8") as fh:
+                current_header = next(csv.reader(fh), [])
+            if current_header != _HEADER:
+                if os.path.exists(self._rotated_path):
+                    os.remove(self._rotated_path)
+                os.rename(self._path, self._rotated_path)
+                with open(self._path, "w", newline="", encoding="utf-8") as fh:
+                    csv.writer(fh).writerow(_HEADER)
+                _LOGGER.info("DataCollector: rotated %s due to header change", self._path)
+        except OSError as exc:
+            _LOGGER.warning("DataCollector: could not validate %s: %s", self._path, exc)
 
     def _rotate_if_needed(self) -> None:
         """Rename current file to *_old.csv when it exceeds _MAX_FILE_SIZE."""
@@ -128,6 +156,6 @@ class DataCollector:
                     os.remove(self._rotated_path)
                 os.rename(self._path, self._rotated_path)
                 self._ensure_header()
-                _LOGGER.info("DataCollector: rotated %s → %s", self._path, self._rotated_path)
+                _LOGGER.info("DataCollector: rotated %s -> %s", self._path, self._rotated_path)
         except OSError as exc:
             _LOGGER.warning("DataCollector: rotation error for %s: %s", self._path, exc)

--- a/custom_components/smart_fan_controller/manifest.json
+++ b/custom_components/smart_fan_controller/manifest.json
@@ -9,5 +9,5 @@
   "codeowners": [
     "@Gamso"
   ],
-  "version": "1.3.0"
+  "version": "1.5.0"
 }

--- a/custom_components/smart_fan_controller/sensor.py
+++ b/custom_components/smart_fan_controller/sensor.py
@@ -1,122 +1,211 @@
 """Sensor platform for Smart Fan Controller."""
 from __future__ import annotations
 
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime, PERCENTAGE
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity import DeviceInfo
+import logging
 
-from .const import DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfTemperature, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
+
+from .const import (
+    DEVICE_NAME,
+    DOMAIN,
+    EFFECTIVE_SLOPE_UNIT,
+    MIN_MODE_PROFILE_SAMPLES,
+    PROFILE_HVAC_MODES,
+    build_entity_id,
+    build_unique_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class _SmartFanEntity(SensorEntity):
-    """Base sensor that wires every subclass to the Smart Fan Controller device.
+    """Base sensor wired to the Smart Fan Controller device."""
 
-    All concrete sensor classes only need to set ``self._entry_id`` and they
-    automatically appear grouped under the same device in the HA UI, without
-    each class having to repeat the ``device_info`` property.
-    """
-
-    _entry_id: str  # Must be set by every subclass __init__
+    _entry_id: str
+    _attr_has_entity_name = True
 
     @property
     def device_info(self) -> DeviceInfo:
         """Link the entity to the Smart Fan Controller device."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry_id)},
-            name="Smart Fan Controller",
+            name=DEVICE_NAME,
         )
+
+
+def _profile_effective_slope_object_key(hvac_mode: str, fan_mode: str) -> str:
+    """Return the canonical object key for a profile effective slope sensor."""
+    return f"{hvac_mode}_{slugify(fan_mode)}_effective_slope"
+
+
+def _build_profile_effective_slope_entities(entry_id: str, controller, known_keys: set[tuple[str, str]]) -> list["SmartFanProfileEffectiveSlopeSensor"]:
+    """Create profile slope sensors for fan modes that do not yet have an entity."""
+    entities: list[SmartFanProfileEffectiveSlopeSensor] = []
+
+    for hvac_mode in PROFILE_HVAC_MODES:
+        for fan_mode in controller.fan_modes or []:
+            key = (hvac_mode, fan_mode)
+            if key in known_keys:
+                continue
+
+            known_keys.add(key)
+            entities.append(SmartFanProfileEffectiveSlopeSensor(entry_id, controller, hvac_mode, fan_mode))
+
+    return entities
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up the sensor platform from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
+    controller = data["controller"]
 
-    # Define all sensors clearly
-    # Format: (Display Name, Data Key, Unit, Device Class, Icon, Entity Category)
     sensor_definitions = [
-        ("Status", "reason", None, None, "mdi:information-outline", EntityCategory.DIAGNOSTIC),
-        ("Fan Mode", "fan_mode", None, SensorDeviceClass.ENUM, "mdi:fan", None),  # Not diagnostic
-        ("Fan Mode - Last change", "minutes_since_last_change", UnitOfTime.MINUTES, SensorDeviceClass.DURATION, "mdi:clock-outline", EntityCategory.DIAGNOSTIC),
-        ("Temperature Projected (10 min)", "projected_temperature", UnitOfTemperature.CELSIUS, SensorDeviceClass.TEMPERATURE, "mdi:chart-bell-curve", EntityCategory.DIAGNOSTIC),
-        ("Temperature Projected Error (10 min)", "projected_temperature_error", UnitOfTemperature.CELSIUS, SensorDeviceClass.TEMPERATURE, "mdi:chart-bell-curve", EntityCategory.DIAGNOSTIC),
-        ("Temperature Error", "temperature_error", UnitOfTemperature.CELSIUS, SensorDeviceClass.TEMPERATURE, "mdi:thermometer-lines", EntityCategory.DIAGNOSTIC),
+        ("Status", "status", "reason", None, None, "mdi:information-outline", EntityCategory.DIAGNOSTIC),
+        ("Fan Mode", "fan_mode", "fan_mode", None, SensorDeviceClass.ENUM, "mdi:fan", None),
+        (
+            "Fan Mode Last Change",
+            "fan_mode_last_change",
+            "minutes_since_last_change",
+            UnitOfTime.MINUTES,
+            SensorDeviceClass.DURATION,
+            "mdi:clock-outline",
+            EntityCategory.DIAGNOSTIC,
+        ),
+        (
+            "Temperature Projected 10 Min",
+            "temperature_projected_10_min",
+            "projected_temperature",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            "mdi:chart-bell-curve",
+            EntityCategory.DIAGNOSTIC,
+        ),
+        (
+            "Temperature Projected Error 10 Min",
+            "temperature_projected_error_10_min",
+            "projected_temperature_error",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            "mdi:chart-bell-curve",
+            EntityCategory.DIAGNOSTIC,
+        ),
+        (
+            "Temperature Error",
+            "temperature_error",
+            "temperature_error",
+            UnitOfTemperature.CELSIUS,
+            SensorDeviceClass.TEMPERATURE,
+            "mdi:thermometer-lines",
+            EntityCategory.DIAGNOSTIC,
+        ),
     ]
 
-    entities = []
-    for name, key, unit, device_class, icon, entity_category in sensor_definitions:
-        entities.append(SmartFanSensor(entry.entry_id, name, key, unit, device_class, icon, entity_category))
+    entities: list[SensorEntity] = [
+        SmartFanSensor(entry.entry_id, name, object_key, controller_key, unit, device_class, icon, entity_category)
+        for name, object_key, controller_key, unit, device_class, icon, entity_category in sensor_definitions
+    ]
 
-    # Add learning sensors (directly linked to controller)
-    controller = data["controller"]
-    entities.append(SmartFanLearningSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearningStatusSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearningSamplesSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearningResponseSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearnedDeadTimeSensor(entry.entry_id, controller))
-    entities.append(SmartFanEffectiveTimeoutSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearnedDeadbandSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearnedSoftErrorSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearnedHardErrorSensor(entry.entry_id, controller))
-    entities.append(SmartFanLearnedLimitTimeoutSensor(entry.entry_id, controller))
+    entities.extend(
+        [
+            SmartFanLearningSensor(entry.entry_id, controller),
+            SmartFanLearningStatusSensor(entry.entry_id, controller),
+            SmartFanLearningSamplesSensor(entry.entry_id, controller),
+            SmartFanLearningResponseSensor(entry.entry_id, controller),
+            SmartFanLearnedDeadTimeSensor(entry.entry_id, controller),
+            SmartFanEffectiveTimeoutSensor(entry.entry_id, controller),
+            SmartFanLearnedDeadbandSensor(entry.entry_id, controller),
+            SmartFanLearnedSoftErrorSensor(entry.entry_id, controller),
+            SmartFanLearnedHardErrorSensor(entry.entry_id, controller),
+            SmartFanLearnedLimitTimeoutSensor(entry.entry_id, controller),
+        ]
+    )
 
-    # Store the list in hass.data for the __init__.py update loop
+    profile_sensor_keys: set[tuple[str, str]] = set()
+    profile_entities = _build_profile_effective_slope_entities(entry.entry_id, controller, profile_sensor_keys)
+    entities.extend(profile_entities)
+
+    if profile_entities:
+        _LOGGER.info(
+            "Created %d initial effective slope profile sensors for %s: %s",
+            len(profile_entities),
+            entry.entry_id,
+            [entity.name for entity in profile_entities],
+        )
+    else:
+        _LOGGER.debug("No fan modes known yet for %s; profile slope sensors will be added later", entry.entry_id)
+
+    data["profile_sensor_keys"] = profile_sensor_keys
     data["sensors"] = entities
+
+    def ensure_profile_sensors() -> None:
+        """Add late-discovered profile slope sensors once fan modes are known."""
+        new_entities = _build_profile_effective_slope_entities(entry.entry_id, controller, profile_sensor_keys)
+        if not new_entities:
+            return
+
+        entities.extend(new_entities)
+        async_add_entities(new_entities)
+        _LOGGER.info(
+            "Added %d effective slope profile sensors for %s: %s",
+            len(new_entities),
+            entry.entry_id,
+            [entity.name for entity in new_entities],
+        )
+
+    data["ensure_profile_sensors"] = ensure_profile_sensors
+
     async_add_entities(entities)
 
 
 class SmartFanSensor(_SmartFanEntity):
-    """A specific sensor for the Smart Fan integration."""
+    """A specific sensor fed by the live controller payload."""
 
     def __init__(
         self,
         entry_id: str,
         name_suffix: str,
+        object_key: str,
         data_key: str,
         unit: str | None,
         device_class: SensorDeviceClass | None,
         icon: str,
         entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC,
     ) -> None:
-        """Initialize the sensor."""
         self._entry_id = entry_id
         self._data_key = data_key
-
-        # This name is what appears in the UI
         self._attr_name = name_suffix
-
-        # Unique ID for internal HA database; HA assigns entity_id from this
-        self._attr_unique_id = f"smart_fan_{data_key}_{entry_id}"
-
+        self._attr_unique_id = build_unique_id(object_key, entry_id)
         self._attr_native_unit_of_measurement = unit
         self._attr_device_class = device_class
         self._attr_native_value = None
         self._attr_icon = icon
         self._attr_entity_category = entity_category
+        self.entity_id = build_entity_id("sensor", object_key)
 
     def update_from_controller(self, data: dict) -> None:
         """Update the sensor value with data from the controller."""
-        new_value = data.get(self._data_key)
-        if new_value is not None:
-            self._attr_native_value = new_value
-            # Caller (the control loop) is responsible for calling async_write_ha_state()
+        if self._data_key in data:
+            self._attr_native_value = data.get(self._data_key)
 
 
 class SmartFanLearningSensor(_SmartFanEntity):
     """Sensor showing learning progress and optimal parameters."""
 
     def __init__(self, entry_id: str, controller) -> None:
-        """Initialize the learning sensor."""
         self._entry_id = entry_id
         self._controller = controller
-
         self._attr_name = "Learning Progress"
-        self._attr_unique_id = f"smart_fan_learning_progress_{entry_id}"
+        self._attr_unique_id = build_unique_id("learning_progress", entry_id)
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_icon = "mdi:school"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", "learning_progress")
 
     @property
     def native_value(self) -> float:
@@ -134,7 +223,6 @@ class SmartFanLearningSensor(_SmartFanEntity):
             "effective_timeout": round(self._controller.get_effective_timeout(), 2),
         }
 
-        # Always compute optimal parameters for continuous monitoring (not applied automatically)
         optimal = self._controller.learning.compute_optimal_parameters()
         if optimal:
             attrs["learned_deadband"] = optimal.get("deadband")
@@ -151,38 +239,35 @@ class SmartFanLearningStatusSensor(_SmartFanEntity):
     """Sensor showing learning readiness status."""
 
     def __init__(self, entry_id: str, controller) -> None:
-        """Initialize the learning status sensor."""
         self._entry_id = entry_id
         self._controller = controller
-
         self._attr_name = "Learning Status"
-        self._attr_unique_id = f"smart_fan_learning_status_{entry_id}"
+        self._attr_unique_id = build_unique_id("learning_status", entry_id)
         self._attr_icon = "mdi:school-outline"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", "learning_status")
 
     @property
     def native_value(self) -> str:
         """Return learning status."""
         if self._controller.learning.is_ready():
             return "Ready"
-        else:
-            progress = self._controller.learning.get_progress()
-            return f"Learning ({progress:.0f}%)"
+        progress = self._controller.learning.get_progress()
+        return f"Learning ({progress:.0f}%)"
 
 
 class SmartFanLearningSamplesSensor(_SmartFanEntity):
     """Sensor showing number of slope samples collected."""
 
     def __init__(self, entry_id: str, controller) -> None:
-        """Initialize the samples sensor."""
         self._entry_id = entry_id
         self._controller = controller
-
         self._attr_name = "Learning Samples"
-        self._attr_unique_id = f"smart_fan_learning_samples_{entry_id}"
+        self._attr_unique_id = build_unique_id("learning_samples", entry_id)
         self._attr_native_unit_of_measurement = "samples"
         self._attr_icon = "mdi:chart-box-outline"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", "learning_samples")
 
     @property
     def native_value(self) -> int:
@@ -208,15 +293,14 @@ class SmartFanLearningResponseSensor(_SmartFanEntity):
     """Sensor showing number of response events recorded."""
 
     def __init__(self, entry_id: str, controller) -> None:
-        """Initialize the response events sensor."""
         self._entry_id = entry_id
         self._controller = controller
-
         self._attr_name = "Learning Response Events"
-        self._attr_unique_id = f"smart_fan_learning_response_events_{entry_id}"
+        self._attr_unique_id = build_unique_id("learning_response_events", entry_id)
         self._attr_native_unit_of_measurement = "events"
         self._attr_icon = "mdi:timer-outline"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", "learning_response_events")
 
     @property
     def native_value(self) -> int:
@@ -228,7 +312,6 @@ class SmartFanLearningResponseSensor(_SmartFanEntity):
         """Return response time statistics."""
         learning = self._controller.learning
         optimal = learning.compute_optimal_parameters()
-
         response_times = [t for _, t in learning.response_events if t > 0]
         avg_response = sum(response_times) / len(response_times) if response_times else 0
 
@@ -248,11 +331,12 @@ class SmartFanLearnedDeadTimeSensor(_SmartFanEntity):
         self._entry_id = entry_id
         self._controller = controller
         self._attr_name = "Learned Dead Time"
-        self._attr_unique_id = f"smart_fan_learned_dead_time_{entry_id}"
+        self._attr_unique_id = build_unique_id("learned_dead_time", entry_id)
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_icon = "mdi:timer-sand"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", "learned_dead_time")
 
     @property
     def native_value(self) -> float:
@@ -275,11 +359,12 @@ class SmartFanEffectiveTimeoutSensor(_SmartFanEntity):
         self._entry_id = entry_id
         self._controller = controller
         self._attr_name = "Effective Timeout"
-        self._attr_unique_id = f"smart_fan_effective_timeout_{entry_id}"
+        self._attr_unique_id = build_unique_id("effective_timeout", entry_id)
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_icon = "mdi:clock-check-outline"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", "effective_timeout")
 
     @property
     def native_value(self) -> float:
@@ -296,33 +381,83 @@ class SmartFanEffectiveTimeoutSensor(_SmartFanEntity):
         }
 
 
+class SmartFanProfileEffectiveSlopeSensor(_SmartFanEntity):
+    """Historized per-profile effective slope sensor for one HVAC/fan combination."""
+
+    def __init__(self, entry_id: str, controller, hvac_mode: str, fan_mode: str) -> None:
+        self._entry_id = entry_id
+        self._controller = controller
+        self._hvac_mode = hvac_mode
+        self._fan_mode = fan_mode
+
+        object_key = _profile_effective_slope_object_key(hvac_mode, fan_mode)
+        self._attr_name = f"{hvac_mode.title()} {fan_mode.title()} Effective Slope"
+        self._attr_unique_id = build_unique_id(object_key, entry_id)
+        self._attr_native_unit_of_measurement = EFFECTIVE_SLOPE_UNIT
+        self._attr_icon = "mdi:chart-line-variant"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", object_key)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the learned effective slope for this profile."""
+        effective_slope = self._controller.learning.get_mode_effective_slope(self._fan_mode, self._hvac_mode)
+        return round(effective_slope, 3) if effective_slope is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose sampling details for the current profile."""
+        samples = self._controller.learning.get_mode_sample_count(self._fan_mode, self._hvac_mode)
+        return {
+            "hvac_mode": self._hvac_mode,
+            "fan_mode": self._fan_mode,
+            "samples": samples,
+            "min_samples_required": MIN_MODE_PROFILE_SAMPLES,
+            "ready": samples >= MIN_MODE_PROFILE_SAMPLES,
+        }
+
+
 class _BaseLearnedParameterSensor(_SmartFanEntity):
     """Base class for learned parameter sensors."""
 
-    def __init__(self, entry_id: str, controller, name: str, unit, device_class, key: str, icon: str = "mdi:brain", current_attr: str | None = None) -> None:
+    def __init__(
+        self,
+        entry_id: str,
+        controller,
+        *,
+        name: str,
+        object_key: str,
+        unit,
+        device_class,
+        learning_key: str,
+        icon: str = "mdi:brain",
+        current_attr: str | None = None,
+    ) -> None:
         self._entry_id = entry_id
         self._controller = controller
-        self._key = key
-        self._current_attr = current_attr  # Attribute to fetch current value from controller
-
+        self._learning_key = learning_key
+        self._current_attr = current_attr
         self._attr_name = name
-        self._attr_unique_id = f"smart_fan_{self._key}_{entry_id}"
+        self._attr_unique_id = build_unique_id(object_key, entry_id)
         self._attr_native_unit_of_measurement = unit
         self._attr_device_class = device_class
         self._attr_icon = icon
-        self._attr_native_value = None  # Initialize with None, will be updated
+        self._attr_native_value = None
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.entity_id = build_entity_id("sensor", object_key)
 
     @property
     def native_value(self):
         """Return the learned value, or current value if not ready yet."""
         optimal = self._controller.learning.compute_optimal_parameters()
         if optimal:
-            return round(optimal.get(self._key), 2)
-        # Before learning is ready, show current value from controller if available
+            value = optimal.get(self._learning_key)
+            return round(value, 2) if value is not None else None
+
         if self._current_attr:
-            val = getattr(self._controller, f"_{self._current_attr}", 0)
-            return round(val, 2) if val else 0
+            value = getattr(self._controller, f"_{self._current_attr}", 0)
+            return round(value, 2) if value else 0
+
         return 0
 
     @property
@@ -344,9 +479,10 @@ class SmartFanLearnedDeadbandSensor(_BaseLearnedParameterSensor):
             entry_id,
             controller,
             name="Learned Deadband",
+            object_key="learned_deadband",
             unit=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
-            key="deadband",
+            learning_key="deadband",
             icon="mdi:thermometer-lines",
             current_attr="deadband",
         )
@@ -360,9 +496,10 @@ class SmartFanLearnedSoftErrorSensor(_BaseLearnedParameterSensor):
             entry_id,
             controller,
             name="Learned Soft Error",
+            object_key="learned_soft_error",
             unit=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
-            key="soft_error",
+            learning_key="soft_error",
             icon="mdi:speedometer-slow",
             current_attr="soft_error",
         )
@@ -376,9 +513,10 @@ class SmartFanLearnedHardErrorSensor(_BaseLearnedParameterSensor):
             entry_id,
             controller,
             name="Learned Hard Error",
+            object_key="learned_hard_error",
             unit=UnitOfTemperature.CELSIUS,
             device_class=SensorDeviceClass.TEMPERATURE,
-            key="hard_error",
+            learning_key="hard_error",
             icon="mdi:speedometer",
             current_attr="hard_error",
         )
@@ -392,9 +530,10 @@ class SmartFanLearnedLimitTimeoutSensor(_BaseLearnedParameterSensor):
             entry_id,
             controller,
             name="Learned Limit Timeout",
+            object_key="learned_limit_timeout",
             unit=UnitOfTime.MINUTES,
             device_class=SensorDeviceClass.DURATION,
-            key="limit_timeout",
+            learning_key="limit_timeout",
             icon="mdi:clock-check-outline",
             current_attr="limit_timeout",
         )

--- a/custom_components/smart_fan_controller/switch.py
+++ b/custom_components/smart_fan_controller/switch.py
@@ -1,14 +1,40 @@
 """Switch platform for Smart Fan Controller."""
 from __future__ import annotations
 
-from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import EntityCategory
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity import DeviceInfo
+import logging
 
-from .const import DOMAIN, CONF_LEARNING_ENABLED
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    CONF_LEARNING_ENABLED,
+    DEVICE_NAME,
+    DOMAIN,
+    build_entity_id,
+    build_unique_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _SmartFanSwitchEntity(SwitchEntity):
+    """Base switch wired to the Smart Fan Controller device."""
+
+    _entry_id: str
+    _attr_has_entity_name = True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link the entity to the Smart Fan Controller device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry_id)},
+            name=DEVICE_NAME,
+        )
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up the switch platform from a config entry."""
@@ -22,58 +48,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-class SmartFanLearningSwitch(SwitchEntity):
-    """Switch to enable/disable learning mode."""
+class SmartFanLearningSwitch(_SmartFanSwitchEntity):  # pylint: disable=abstract-method
+    """Switch to enable or disable learning mode."""
 
     def __init__(self, entry_id: str, controller, entry: ConfigEntry, hass: HomeAssistant) -> None:
-        """Initialize the learning switch."""
         self._entry_id = entry_id
         self._controller = controller
         self._entry = entry
         self._hass = hass
 
         self._attr_name = "Learning Enabled"
-        self._attr_unique_id = f"smart_fan_learning_enabled_{entry_id}"
+        self._attr_unique_id = build_unique_id("learning_enabled", entry_id)
         self._attr_icon = "mdi:brain"
         self._attr_entity_category = EntityCategory.CONFIG
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Link to the Smart Fan device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._entry_id)},
-            name="Smart Fan Controller",
-        )
+        self.entity_id = build_entity_id("switch", "learning_enabled")
 
     @property
     def is_on(self) -> bool:
         """Return true if learning is enabled."""
         return self._controller.learning_enabled
 
-    def turn_on(self, **kwargs) -> None:
-        """Turn on learning mode (sync — HA calls async_turn_on when available)."""
-        self._controller.learning_enabled = True
-
-    def turn_off(self, **kwargs) -> None:
-        """Turn off learning mode (sync — HA calls async_turn_off when available)."""
-        self._controller.learning_enabled = False
-
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on learning mode."""
         self._controller.learning_enabled = True
-
-        # Update config entry to persist the setting
-        new_options = {**self._entry.options, CONF_LEARNING_ENABLED: True}
-        self._hass.config_entries.async_update_entry(self._entry, options=new_options)
-
+        self._hass.config_entries.async_update_entry(
+            self._entry,
+            options={**self._entry.options, CONF_LEARNING_ENABLED: True},
+        )
+        _LOGGER.info("Learning enabled for %s", self._entry.entry_id)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off learning mode."""
         self._controller.learning_enabled = False
-
-        # Update config entry to persist the setting
-        new_options = {**self._entry.options, CONF_LEARNING_ENABLED: False}
-        self._hass.config_entries.async_update_entry(self._entry, options=new_options)
-
+        self._hass.config_entries.async_update_entry(
+            self._entry,
+            options={**self._entry.options, CONF_LEARNING_ENABLED: False},
+        )
+        _LOGGER.info("Learning disabled for %s", self._entry.entry_id)
         self.async_write_ha_state()
+

--- a/custom_components/smart_fan_controller/thermal_learning.py
+++ b/custom_components/smart_fan_controller/thermal_learning.py
@@ -17,6 +17,7 @@ class ThermalLearning:
         self._learning_window_hours = 168  # 7 days sliding window
         self._min_samples = MIN_SAMPLES_LEARNING  # Minimum samples for initial readiness (48-72h typical activity)
         self._ready_once = False  # Flag to track if we've ever reached ready state
+        self._profile_ready_logged: set[tuple[str, str]] = set()
 
         # Incremental statistics using Welford's algorithm
         self._slope_count = 0  # Number of slope samples processed
@@ -37,6 +38,7 @@ class ThermalLearning:
         self._slope_max = 0.0
         self._ready_once = False
         self._optimal_cache = None
+        self._profile_ready_logged.clear()
         _LOGGER.info("Learning: reset requested; data cleared")
 
     def add_slope_sample(self, fan_mode: str, slope: float, temperature_error: float = 0, hvac_mode: str = "unknown", is_window_open: bool = False):
@@ -60,11 +62,37 @@ class ThermalLearning:
             return
 
         self._slope_samples.append((time.time(), fan_mode, slope, hvac_mode))
-        _LOGGER.debug("Learning: Collected slope sample #%d (fan=%s, slope=%.2f, err=%.2f, hvac=%s)", len(self._slope_samples), fan_mode, slope, temperature_error, hvac_mode)
+        profile_samples = self.get_mode_sample_count(fan_mode, hvac_mode)
+        _LOGGER.debug(
+            "Learning: Collected slope sample #%d (fan=%s, slope=%.2f, err=%.2f, hvac=%s, profile=%d/%d)",
+            len(self._slope_samples),
+            fan_mode,
+            slope,
+            temperature_error,
+            hvac_mode,
+            profile_samples,
+            MIN_MODE_PROFILE_SAMPLES,
+        )
 
         self._optimal_cache = None
 
         self._update_slope_stats(abs(slope))
+
+        profile_key = (hvac_mode, fan_mode)
+        if (
+            hvac_mode != "unknown"
+            and profile_samples >= MIN_MODE_PROFILE_SAMPLES
+            and profile_key not in self._profile_ready_logged
+        ):
+            self._profile_ready_logged.add(profile_key)
+            effective_slope = self.get_mode_effective_slope(fan_mode, hvac_mode)
+            _LOGGER.info(
+                "Learning: profile %s/%s is ready with %d samples (effective_slope=%s)",
+                hvac_mode,
+                fan_mode,
+                profile_samples,
+                f"{effective_slope:.3f}" if effective_slope is not None else "n/a",
+            )
 
         # Cleanup: keep only data within sliding window (7 days)
         cutoff_time = time.time() - (self._learning_window_hours * 3600)
@@ -73,6 +101,10 @@ class ThermalLearning:
 
         if len(self._slope_samples) < before:
             self.recompute_slope_stats()
+            _LOGGER.debug(
+                "Learning: dropped %d expired slope samples from the sliding window",
+                before - len(self._slope_samples),
+            )
 
     def _update_slope_stats(self, abs_slope: float) -> None:
         """Update slope statistics incrementally using Welford's algorithm."""
@@ -94,7 +126,13 @@ class ThermalLearning:
 
         # Cleanup: keep only data within sliding window (7 days)
         cutoff_time = time.time() - (self._learning_window_hours * 3600)
+        before = len(self._response_events)
         self._response_events = [(ts, t) for ts, t in self._response_events if ts > cutoff_time]
+        if len(self._response_events) < before:
+            _LOGGER.debug(
+                "Learning: dropped %d expired response events from the sliding window",
+                before - len(self._response_events),
+            )
 
     def slope_sample_count(self) -> int:
         """Return number of collected slope samples."""
@@ -198,6 +236,35 @@ class ThermalLearning:
         avg = statistics.mean(matching_slopes)
         return -avg if hvac_mode == "cool" else avg
 
+    def get_mode_sample_count(self, fan_mode: str, hvac_mode: str) -> int:
+        """Return the number of collected samples for one fan/HVAC profile."""
+        return sum(1 for (_, fm, _, hm) in self._slope_samples if fm == fan_mode and hm == hvac_mode)
+
+    def get_known_fan_modes(self) -> list[str]:
+        """Return unique fan modes seen in slope samples, preserving first-seen order."""
+        seen: dict[str, None] = {}
+        for _, fan_mode, _, _ in self._slope_samples:
+            seen[fan_mode] = None
+        return list(seen.keys())
+
+    def get_mode_profiles(self, hvac_mode: str, fan_modes: list[str] | None = None) -> dict[str, dict]:
+        """Return the learned profile summary for one HVAC mode."""
+        if fan_modes:
+            ordered_modes = list(dict.fromkeys(fan_modes))
+        else:
+            ordered_modes = sorted({fm for (_, fm, _, hm) in self._slope_samples if hm == hvac_mode})
+
+        profiles: dict[str, dict] = {}
+        for fan_mode in ordered_modes:
+            effective_slope = self.get_mode_effective_slope(fan_mode, hvac_mode)
+            sample_count = self.get_mode_sample_count(fan_mode, hvac_mode)
+            profiles[fan_mode] = {
+                "effective_slope": round(effective_slope, 3) if effective_slope is not None else None,
+                "samples": sample_count,
+                "ready": effective_slope is not None,
+            }
+        return profiles
+
     def compute_optimal_parameters(self) -> dict:
         """Calculate optimal parameters from learned data.
 
@@ -280,6 +347,11 @@ class ThermalLearning:
         self._slope_m2 = 0.0
         self._slope_max = 0.0
         self._optimal_cache = None  # Invalidate cache when stats are rebuilt
+        self._profile_ready_logged = {
+            (hm, fm)
+            for (_, fm, _, hm) in self._slope_samples
+            if hm != "unknown" and self.get_mode_sample_count(fm, hm) >= MIN_MODE_PROFILE_SAMPLES
+        }
 
         for sample in self._slope_samples:
             self._update_slope_stats(abs(sample[2]))
@@ -303,9 +375,11 @@ class ThermalLearning:
         # Migrate slope_samples: support both 3-tuple (old) and 4-tuple (new)
         raw_samples = data.get("slope_samples", [])
         instance._slope_samples = []
+        migrated_legacy_samples = 0
         for sample in raw_samples:
             if len(sample) == 3:
                 instance._slope_samples.append((sample[0], sample[1], sample[2], "unknown"))
+                migrated_legacy_samples += 1
             else:
                 instance._slope_samples.append(tuple(sample))
 
@@ -330,5 +404,12 @@ class ThermalLearning:
             instance._ready_once = True
 
         instance._optimal_cache = None
+        if migrated_legacy_samples:
+            _LOGGER.info("Learning: migrated %d legacy slope samples to include hvac_mode", migrated_legacy_samples)
+        _LOGGER.debug(
+            "Learning: restored %d slope samples and %d response events from storage",
+            len(instance._slope_samples),
+            len(instance._response_events),
+        )
 
         return instance

--- a/custom_components/smart_fan_controller/translations/en.json
+++ b/custom_components/smart_fan_controller/translations/en.json
@@ -12,7 +12,9 @@
                     "hard_error": "Hard Error Threshold (°C)",
                     "limit_timeout": "Interval Before Forcing Change (minutes)",
                     "learning_enabled": "Enable Automatic Learning",
-                    "data_collection": "Enable Data Collection (beta)"
+                    "data_collection": "Enable Data Collection (beta)",
+                    "defrost_entity": "Defrost Entity (optional)",
+                    "operating_entity": "Heat Pump Operating Entity (optional)"
                 },
                 "data_description": {
                     "climate_entity": "Must come from a Versatile Thermostat.",
@@ -22,7 +24,9 @@
                     "hard_error": "Range: 0.0-10.0 °C. Default: 0.6 °C.",
                     "limit_timeout": "Range: 10-120 min. Default: 15 min.",
                     "learning_enabled": "Enable automatic learning of optimal parameters. When ready, settings will be applied automatically.",
-                    "data_collection": "Records one CSV row every 2 minutes in the Home Assistant config folder, alongside configuration.yaml: smart_fan_controller_data_XXXXXXXX.csv (max 10 MB, auto-rotated). Useful for reproducing algorithm behaviour and identifying improvements during the beta phase."
+                    "data_collection": "Records one CSV row every 2 minutes in the Home Assistant config folder, alongside configuration.yaml: smart_fan_controller_data_XXXXXXXX.csv (max 10 MB, auto-rotated). Useful for reproducing algorithm behaviour and identifying improvements during the beta phase.",
+                    "defrost_entity": "Optional: binary sensor, sensor or input_boolean that indicates when the heat pump is in defrost mode.",
+                    "operating_entity": "Optional: binary sensor, sensor or input_boolean that indicates when the heat pump compressor is actively running. Used to prevent useless fan changes while the compressor is off."
                 },
                 "error": {
                     "invalid_climate_entity": "This entity must come from Versatile Thermostat.",
@@ -44,7 +48,9 @@
                     "hard_error": "Hard Error Threshold (°C)",
                     "limit_timeout": "Interval Before Forcing Change (minutes)",
                     "learning_enabled": "Enable Automatic Learning",
-                    "data_collection": "Enable Data Collection (beta)"
+                    "data_collection": "Enable Data Collection (beta)",
+                    "defrost_entity": "Defrost Entity (optional)",
+                    "operating_entity": "Heat Pump Operating Entity (optional)"
                 },
                 "data_description": {
                     "climate_entity": "Must come from a Versatile Thermostat.",
@@ -54,7 +60,9 @@
                     "hard_error": "Range: 0.0-10.0 °C. Default: 0.6 °C.",
                     "limit_timeout": "Range: 10-120 min. Default: 15 min.",
                     "learning_enabled": "Enable automatic learning of optimal parameters. When ready, settings will be applied automatically.",
-                    "data_collection": "Records one CSV row every 2 minutes in the Home Assistant config folder, alongside configuration.yaml: smart_fan_controller_data_XXXXXXXX.csv (max 10 MB, auto-rotated). Useful for reproducing algorithm behaviour and identifying improvements during the beta phase."
+                    "data_collection": "Records one CSV row every 2 minutes in the Home Assistant config folder, alongside configuration.yaml: smart_fan_controller_data_XXXXXXXX.csv (max 10 MB, auto-rotated). Useful for reproducing algorithm behaviour and identifying improvements during the beta phase.",
+                    "defrost_entity": "Optional: binary sensor, sensor or input_boolean that indicates when the heat pump is in defrost mode.",
+                    "operating_entity": "Optional: binary sensor, sensor or input_boolean that indicates when the heat pump compressor is actively running. Used to prevent useless fan changes while the compressor is off."
                 },
                 "error": {
                     "invalid_climate_entity": "This entity must come from Versatile Thermostat.",

--- a/custom_components/smart_fan_controller/translations/fr.json
+++ b/custom_components/smart_fan_controller/translations/fr.json
@@ -12,17 +12,21 @@
                     "hard_error": "Seuil d'erreur élevée (°C)",
                     "limit_timeout": "Intervalle avant de forcer un changement (minutes)",
                     "learning_enabled": "Activer l'apprentissage automatique",
-                    "data_collection": "Activer la collecte de données (bêta)"
+                    "data_collection": "Activer la collecte de données (bêta)",
+                    "defrost_entity": "Entité dégivrage (optionnel)",
+                    "operating_entity": "Entité fonctionnement PAC (optionnel)"
                 },
                 "data_description": {
                     "climate_entity": "Doit provenir de Versatile Thermostat.",
-                    "deadband": "Plage : 0.0-5.0 °C. Défaut : 0.2 °C.",
-                    "min_interval": "Plage : 1-60 min. Défaut : 10 min.",
-                    "soft_error": "Plage : 0.0-10.0 °C. Défaut : 0.3 °C.",
-                    "hard_error": "Plage : 0.0-10.0 °C. Défaut : 0.6 °C.",
-                    "limit_timeout": "Plage : 10-120 min. Défaut : 15 min.",
+                    "deadband": "Plage : 0.0-5.0 °C. Défaut : 0.2 °C.",
+                    "min_interval": "Plage : 1-60 min. Défaut : 10 min.",
+                    "soft_error": "Plage : 0.0-10.0 °C. Défaut : 0.3 °C.",
+                    "hard_error": "Plage : 0.0-10.0 °C. Défaut : 0.6 °C.",
+                    "limit_timeout": "Plage : 10-120 min. Défaut : 15 min.",
                     "learning_enabled": "Activer l'apprentissage automatique des paramètres optimaux. Quand prêt, les paramètres seront appliqués automatiquement.",
-                    "data_collection": "Enregistre une ligne CSV toutes les 2 minutes dans le dossier de configuration Home Assistant, à côté de configuration.yaml : smart_fan_controller_data_XXXXXXXX.csv (max 10 Mo, rotation automatique). Utile pour reproduire le comportement de l'algorithme et identifier des améliorations pendant la phase bêta."
+                    "data_collection": "Enregistre une ligne CSV toutes les 2 minutes dans le dossier de configuration Home Assistant, à côté de configuration.yaml : smart_fan_controller_data_XXXXXXXX.csv (max 10 Mo, rotation automatique). Utile pour reproduire le comportement de l'algorithme et identifier des améliorations pendant la phase bêta.",
+                    "defrost_entity": "Optionnel : binary sensor, sensor ou input_boolean indiquant quand la PAC est en dégivrage.",
+                    "operating_entity": "Optionnel : binary sensor, sensor ou input_boolean indiquant quand le compresseur de la PAC est en marche. Utilisé pour éviter des changements de ventilation inutiles quand le compresseur est à l'arrêt."
                 },
                 "error": {
                     "invalid_climate_entity": "Cette entité doit provenir de Versatile Thermostat.",
@@ -44,17 +48,21 @@
                     "hard_error": "Seuil d'erreur élevée (°C)",
                     "limit_timeout": "Intervalle avant de forcer un changement (minutes)",
                     "learning_enabled": "Activer l'apprentissage automatique",
-                    "data_collection": "Activer la collecte de données (bêta)"
+                    "data_collection": "Activer la collecte de données (bêta)",
+                    "defrost_entity": "Entité dégivrage (optionnel)",
+                    "operating_entity": "Entité fonctionnement PAC (optionnel)"
                 },
                 "data_description": {
                     "climate_entity": "Doit provenir de Versatile Thermostat.",
-                    "deadband": "Plage : 0.0-5.0 °C. Défaut : 0.2 °C.",
-                    "min_interval": "Plage : 1-60 min. Défaut : 10 min.",
-                    "soft_error": "Plage : 0.0-10.0 °C. Défaut : 0.3 °C.",
-                    "hard_error": "Plage : 0.0-10.0 °C. Défaut : 0.6 °C.",
-                    "limit_timeout": "Plage : 10-120 min. Défaut : 15 min.",
+                    "deadband": "Plage : 0.0-5.0 °C. Défaut : 0.2 °C.",
+                    "min_interval": "Plage : 1-60 min. Défaut : 10 min.",
+                    "soft_error": "Plage : 0.0-10.0 °C. Défaut : 0.3 °C.",
+                    "hard_error": "Plage : 0.0-10.0 °C. Défaut : 0.6 °C.",
+                    "limit_timeout": "Plage : 10-120 min. Défaut : 15 min.",
                     "learning_enabled": "Activer l'apprentissage automatique des paramètres optimaux. Quand prêt, les paramètres seront appliqués automatiquement.",
-                    "data_collection": "Enregistre une ligne CSV toutes les 2 minutes dans le dossier de configuration Home Assistant, à côté de configuration.yaml : smart_fan_controller_data_XXXXXXXX.csv (max 10 Mo, rotation automatique). Utile pour reproduire le comportement de l'algorithme et identifier des améliorations pendant la phase bêta."
+                    "data_collection": "Enregistre une ligne CSV toutes les 2 minutes dans le dossier de configuration Home Assistant, à côté de configuration.yaml : smart_fan_controller_data_XXXXXXXX.csv (max 10 Mo, rotation automatique). Utile pour reproduire le comportement de l'algorithme et identifier des améliorations pendant la phase bêta.",
+                    "defrost_entity": "Optionnel : binary sensor, sensor ou input_boolean indiquant quand la PAC est en dégivrage.",
+                    "operating_entity": "Optionnel : binary sensor, sensor ou input_boolean indiquant quand le compresseur de la PAC est en marche. Utilisé pour éviter des changements de ventilation inutiles quand le compresseur est à l'arrêt."
                 },
                 "error": {
                     "invalid_climate_entity": "Cette entité doit provenir de Versatile Thermostat.",

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "domain": "smart_fan_controller",
     "content_in_root": false,
     "render_readme": true,
-    "homeassistant": "2026.2.2"
+    "homeassistant": "2026.3.4"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 # Development and Testing Requirements
 pytest
 pytest-asyncio
-pytest-homeassistant-custom-component
+pytest-homeassistant-custom-component==0.13.316

--- a/tests/test_data_collection.py
+++ b/tests/test_data_collection.py
@@ -1,0 +1,159 @@
+"""Tests for async-safe CSV data collection."""
+
+import csv
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.smart_fan_controller import async_setup_entry
+from custom_components.smart_fan_controller.const import CONF_CLIMATE_ENTITY, CONF_DATA_COLLECTION
+from custom_components.smart_fan_controller.data_collection import DataCollector, _HEADER
+
+
+def _make_executor_hass() -> MagicMock:
+    """Return a hass mock whose executor job runs inline during tests."""
+    hass = MagicMock()
+
+    async def run_in_executor(target, *args):
+        return target(*args)
+
+    hass.async_add_executor_job = AsyncMock(side_effect=run_in_executor)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_async_initialize_creates_header(tmp_path: Path) -> None:
+    """The collector should create its CSV header via the executor."""
+    hass = _make_executor_hass()
+    collector = DataCollector(hass, str(tmp_path), "123456789")
+
+    await collector.async_initialize()
+
+    with open(collector.path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows == [_HEADER]
+    hass.async_add_executor_job.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_record_appends_row(tmp_path: Path) -> None:
+    """The collector should append a data row after initialization."""
+    hass = _make_executor_hass()
+    collector = DataCollector(hass, str(tmp_path), "123456789")
+
+    await collector.async_initialize()
+    await collector.async_record(
+        hvac_mode="heat",
+        current_temp=20.1234,
+        target_temp=21.0,
+        vtherm_slope=-0.2468,
+        is_window_open=False,
+        decision={
+            "temperature_error": 0.8765,
+            "projected_temperature": 20.5,
+            "projected_temperature_error": 0.5,
+            "minutes_since_last_change": 12.345,
+            "current_fan": "low",
+            "fan_mode": "medium",
+            "reason": "Strong recovery",
+        },
+        phase="TRANSIENT",
+        effective_slope=-0.2468,
+        effective_timeout=15.4321,
+        force=True,
+        learning_ready=False,
+        dead_time=10.987,
+    )
+
+    with open(collector.path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+
+    assert len(rows) == 2
+    assert rows[0] == _HEADER
+    assert rows[1][0].endswith("Z")
+    assert rows[1][1:] == [
+        "heat",
+        "20.123",
+        "21.0",
+        "0.876",
+        "-0.2468",
+        "-0.2468",
+        "20.5",
+        "0.5",
+        "TRANSIENT",
+        "12.35",
+        "15.43",
+        "low",
+        "medium",
+        "1",
+        "Strong recovery",
+        "0",
+        "10.99",
+        "0",
+        "0",
+        "0",
+    ]
+    assert hass.async_add_executor_job.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_initialize_rotates_file_on_header_change(tmp_path: Path) -> None:
+    """The collector should rotate the active CSV when the schema changes."""
+    legacy_path = tmp_path / "smart_fan_controller_data_12345678.csv"
+    rotated_path = tmp_path / "smart_fan_controller_data_12345678_old.csv"
+    legacy_path.write_text("timestamp,hvac_mode\n2026-01-01T00:00:00Z,heat\n", encoding="utf-8")
+
+    hass = _make_executor_hass()
+    collector = DataCollector(hass, str(tmp_path), "123456789")
+
+    await collector.async_initialize()
+
+    with open(collector.path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows == [_HEADER]
+    assert rotated_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_initializes_data_collector() -> None:
+    """Integration setup should await collector initialization before continuing."""
+    hass = MagicMock()
+    hass.data = {}
+    hass.config = MagicMock()
+    hass.config.config_dir = "/tmp"
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.services = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+
+    entry = MagicMock()
+    entry.entry_id = "123456789"
+    entry.data = {
+        CONF_CLIMATE_ENTITY: "climate.test",
+        CONF_DATA_COLLECTION: True,
+    }
+    entry.options = {}
+    entry.async_on_unload = MagicMock()
+
+    fake_store = AsyncMock()
+    fake_store.async_load = AsyncMock(return_value=None)
+    fake_store.async_save = AsyncMock()
+
+    fake_collector = MagicMock()
+    fake_collector.path = "/tmp/smart_fan_controller_data_12345678.csv"
+    fake_collector.async_initialize = AsyncMock()
+
+    with patch("custom_components.smart_fan_controller.Store", return_value=fake_store):
+        with patch("custom_components.smart_fan_controller.DataCollector", return_value=fake_collector) as collector_cls:
+            with patch("custom_components.smart_fan_controller.async_track_time_interval", return_value=MagicMock()):
+                with patch("custom_components.smart_fan_controller.async_track_state_change_event", return_value=MagicMock()):
+                    result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    collector_cls.assert_called_once_with(hass, hass.config.config_dir, entry.entry_id)
+    fake_collector.async_initialize.assert_awaited_once()

--- a/tests/test_defrost.py
+++ b/tests/test_defrost.py
@@ -1,0 +1,165 @@
+"""Tests for defrost protection in the controller."""
+# pylint: disable=redefined-outer-name,protected-access
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.smart_fan_controller.controller import SmartFanController
+from custom_components.smart_fan_controller.const import (
+    DEFAULT_DEADBAND,
+    DEFAULT_MIN_INTERVAL,
+    DEFAULT_SOFT_ERROR,
+    DEFAULT_HARD_ERROR,
+)
+
+FAN_MODES = ["silent", "low", "med", "high", "superhigh"]
+DEFAULT_CONFIG = {
+    "deadband": DEFAULT_DEADBAND,
+    "min_interval": DEFAULT_MIN_INTERVAL,
+    "soft_error": DEFAULT_SOFT_ERROR,
+    "hard_error": DEFAULT_HARD_ERROR,
+}
+
+
+@pytest.fixture
+def controller():
+    """Create a SmartFanController instance for testing."""
+    return SmartFanController(fan_modes=FAN_MODES, **DEFAULT_CONFIG)
+
+
+class TestDefrostProtection:
+    """Tests that defrost protection blocks step-down decisions."""
+
+    def test_defrost_blocks_braking(self, controller):
+        """During defrost, braking (step-down on overshoot) should be blocked when under target."""
+        # Set up controller state: strong positive slope that triggers B (braking)
+        # but we're still under target, so defrost should protect
+        controller._previous_slope = 0.0
+        controller._now = 0.0
+        controller._last_change_time = 0.0
+        controller._defrost_active = True
+        controller._defrost_start_time = 0.0
+
+        with patch("time.time", return_value=1200.0):  # 20 min later
+            result = controller.calculate_decision(
+                current_temp=19.9,
+                target_temp=20.0,
+                vtherm_slope=2.0,  # Very strong slope that would cause braking
+                hvac_mode="heat",
+                current_fan="high",
+            )
+
+        assert "Defrost hold" in result["reason"]
+        assert result["fan_mode"] == "high"  # Should NOT step down
+
+    def test_defrost_blocks_favorable_slope_reduction(self, controller):
+        """During defrost, maintenance favorable slope reduction should be blocked."""
+        controller._previous_slope = 0.0
+        controller._slope_at_last_change = 0.0
+        controller._now = 0.0
+        controller._last_change_time = 0.0
+        controller._defrost_active = True
+        controller._defrost_start_time = 0.0
+
+        with patch("time.time", return_value=1200.0):
+            result = controller.calculate_decision(
+                current_temp=19.85,
+                target_temp=20.0,
+                vtherm_slope=0.6,
+                hvac_mode="heat",
+                current_fan="superhigh",
+            )
+
+        assert "Defrost hold" in result["reason"]
+        assert result["fan_mode"] == "superhigh"
+
+    def test_defrost_allows_emergency(self, controller):
+        """Emergency should still work during defrost."""
+        controller._defrost_active = True
+        controller._defrost_start_time = 1000.0
+
+        with patch("time.time", return_value=1200.0):
+            result = controller.calculate_decision(
+                current_temp=18.0,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="heat",
+                current_fan="low",
+            )
+
+        assert "Emergency" in result["reason"]
+        assert result["fan_mode"] == "superhigh"
+
+    def test_defrost_output_includes_flag(self, controller):
+        """The decision output should include defrost_active flag."""
+        with patch("time.time", return_value=1000.0):
+            result = controller.calculate_decision(
+                current_temp=20.0,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="heat",
+                current_fan="med",
+            )
+
+        assert "defrost_active" in result
+        assert result["defrost_active"] is False
+
+
+class TestDefrostLearningProtection:
+    """Tests that learning samples are excluded during defrost."""
+
+    def test_learning_skipped_during_defrost(self, controller):
+        """Learning should NOT collect slope samples during active defrost."""
+        controller._defrost_active = True
+        controller._defrost_start_time = 1000.0
+        initial_count = controller.learning.slope_sample_count()
+
+        with patch("time.time", return_value=1200.0):
+            controller.calculate_decision(
+                current_temp=19.5,
+                target_temp=20.0,
+                vtherm_slope=0.8,
+                hvac_mode="heat",
+                current_fan="high",
+            )
+
+        assert controller.learning.slope_sample_count() == initial_count
+
+    def test_response_events_excluded_during_defrost(self, controller):
+        """Response time events should NOT be recorded during active defrost."""
+        controller._defrost_active = True
+        controller._defrost_start_time = 1000.0
+        controller.previous_slope = 0.0
+        controller._last_change_time = 1000.0 - (5 * 60)  # 5 min ago
+        initial_events = controller.learning.response_event_count()
+
+        # slope change from 0.0 → 0.8 would normally trigger a response event
+        with patch("time.time", return_value=1000.0):
+            controller.calculate_decision(
+                current_temp=19.5,
+                target_temp=20.0,
+                vtherm_slope=0.8,
+                hvac_mode="heat",
+                current_fan="high",
+            )
+
+        assert controller.learning.response_event_count() == initial_events
+
+    def test_learning_resumes_after_defrost_expires(self, controller):
+        """Learning should resume after defrost cooldown expires."""
+        controller._defrost_active = True
+        controller._defrost_start_time = 0.0
+        initial_count = controller.learning.slope_sample_count()
+
+        # 25 minutes after defrost start → cooldown expired
+        with patch("time.time", return_value=1500.0):
+            controller.calculate_decision(
+                current_temp=19.5,
+                target_temp=20.0,
+                vtherm_slope=0.8,
+                hvac_mode="heat",
+                current_fan="high",
+            )
+
+        # Learning should have collected a sample (slope 0.8 > 0.15 threshold)
+        assert controller.learning.slope_sample_count() > initial_count

--- a/tests/test_entity_migration.py
+++ b/tests/test_entity_migration.py
@@ -1,0 +1,68 @@
+"""Tests for entity naming migration."""
+
+import pytest
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.smart_fan_controller import _async_migrate_entity_registry
+from custom_components.smart_fan_controller.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_entity_registry_migration_renames_legacy_entities(hass) -> None:
+    """Legacy smart_fan_* entities should be migrated to smart_fan_controller_*."""
+    registry = er.async_get(hass)
+    await registry.async_load()
+
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="entry123")
+    entry.add_to_hass(hass)
+
+    registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "smart_fan_reason_entry123",
+        config_entry=entry,
+        suggested_object_id="Status",
+        original_name="Status",
+        has_entity_name=False,
+    )
+    registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "smart_fan_learned_dead_time_entry123",
+        config_entry=entry,
+        suggested_object_id="Learned Dead Time",
+        original_name="Learned Dead Time",
+        has_entity_name=False,
+    )
+    registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        "smart_fan_learning_enabled_entry123",
+        config_entry=entry,
+        suggested_object_id="Learning Enabled",
+        original_name="Learning Enabled",
+        has_entity_name=False,
+    )
+
+    await _async_migrate_entity_registry(hass, entry)
+
+    status = registry.async_get("sensor.smart_fan_controller_status")
+    learned_dead_time = registry.async_get("sensor.smart_fan_controller_learned_dead_time")
+    learning_enabled = registry.async_get("switch.smart_fan_controller_learning_enabled")
+
+    assert status is not None
+    assert status.unique_id == "smart_fan_controller_status_entry123"
+    assert status.has_entity_name is True
+
+    assert learned_dead_time is not None
+    assert learned_dead_time.unique_id == "smart_fan_controller_learned_dead_time_entry123"
+    assert learned_dead_time.has_entity_name is True
+
+    assert learning_enabled is not None
+    assert learning_enabled.unique_id == "smart_fan_controller_learning_enabled_entry123"
+    assert learning_enabled.has_entity_name is True
+
+    assert registry.async_get("sensor.status") is None
+    assert registry.async_get("sensor.learned_dead_time") is None
+    assert registry.async_get("switch.learning_enabled") is None

--- a/tests/test_hvac_idle.py
+++ b/tests/test_hvac_idle.py
@@ -1,0 +1,214 @@
+"""Tests for HVAC idle (compressor off) detection and protection."""
+# pylint: disable=redefined-outer-name,protected-access
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.smart_fan_controller.controller import SmartFanController
+from custom_components.smart_fan_controller.const import (
+    DEFAULT_DEADBAND,
+    DEFAULT_MIN_INTERVAL,
+    DEFAULT_SOFT_ERROR,
+    DEFAULT_HARD_ERROR,
+)
+
+FAN_MODES = ["silent", "low", "med", "high", "superhigh"]
+DEFAULT_CONFIG = {
+    "deadband": DEFAULT_DEADBAND,
+    "min_interval": DEFAULT_MIN_INTERVAL,
+    "soft_error": DEFAULT_SOFT_ERROR,
+    "hard_error": DEFAULT_HARD_ERROR,
+}
+
+
+@pytest.fixture
+def controller():
+    """Create a SmartFanController instance for testing."""
+    return SmartFanController(fan_modes=FAN_MODES, **DEFAULT_CONFIG)
+
+
+def _prime_learning_profiles(ctrl: SmartFanController) -> None:
+    """Feed enough slope samples for all profiles to become ready."""
+    for _ in range(60):
+        ctrl.learning.add_slope_sample("silent", 0.15, 0.8, "heat")
+        ctrl.learning.add_slope_sample("low", 0.25, 0.8, "heat")
+        ctrl.learning.add_slope_sample("med", 0.9, 0.8, "heat")
+        ctrl.learning.add_slope_sample("high", 1.5, 0.8, "heat")
+        ctrl.learning.add_slope_sample("superhigh", 2.0, 0.8, "heat")
+    ctrl.learning.add_response_event(8.0)
+    ctrl.learning.add_response_event(10.0)
+    ctrl.learning.add_response_event(12.0)
+
+
+class TestHvacIdleControllerHeat:
+    """Controller blocks step-up decisions when HVAC compressor is idle."""
+
+    def test_zone_c_blocked_during_idle(self, controller):
+        """Zone C (recovery): step-up should be blocked when compressor is off."""
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=19.6,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="heat",
+                current_fan="low",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "low"
+        assert "HVAC idle" in result["reason"]
+        assert result["hvac_idle"] is True
+
+    def test_zone_c_allowed_when_not_idle(self, controller):
+        """Zone C (recovery): step-up should work normally when compressor is running."""
+        controller._last_change_time = 3600.0 - (DEFAULT_MIN_INTERVAL * 60 + 60)
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=19.6,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="heat",
+                current_fan="low",
+                is_hvac_idle=False,
+            )
+        assert result["fan_mode"] == "med"
+        assert "recovery" in result["reason"]
+
+    def test_zone_d_blocked_during_idle(self, controller):
+        """Zone D (drift): step-up should be blocked when compressor is off."""
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=19.9,
+                target_temp=20.0,
+                vtherm_slope=-0.3,
+                hvac_mode="heat",
+                current_fan="med",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "med"
+        assert "HVAC idle" in result["reason"]
+
+    def test_zone_a_emergency_not_blocked_by_idle(self, controller):
+        """Zone A: emergency should override idle protection."""
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=19.0,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="heat",
+                current_fan="low",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "superhigh"
+        assert "Emergency" in result["reason"]
+
+    def test_zone_a_setpoint_drop_not_blocked_by_idle(self, controller):
+        """Zone A-bis: setpoint drop should work even during idle."""
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=22.5,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="heat",
+                current_fan="high",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "silent"
+        assert "Setpoint drop" in result["reason"]
+
+    def test_zone_b_braking_allowed_during_idle(self, controller):
+        """Zone B: braking step-down should work during idle."""
+        controller.previous_slope = 0.3
+        controller._last_change_time = 3600.0 - (DEFAULT_MIN_INTERVAL * 60 + 60)
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=19.95,
+                target_temp=20.0,
+                vtherm_slope=3.0,
+                hvac_mode="heat",
+                current_fan="high",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "med"
+        assert "Braking" in result["reason"]
+
+    def test_zone_e_step_down_allowed_during_idle(self, controller):
+        """Zone E: over-target step-down should work during idle."""
+        controller.previous_slope = 0.3
+        controller._last_change_time = 3600.0 - (16 * 60)
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=20.5,
+                target_temp=20.0,
+                vtherm_slope=0.3,
+                hvac_mode="heat",
+                current_fan="high",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "med"
+        assert "Over-target" in result["reason"]
+
+
+class TestHvacIdleLearningExclusion:
+    """Learning data should be excluded during HVAC idle periods."""
+
+    def test_slope_samples_excluded_during_idle(self, controller):
+        """Slope samples should NOT be recorded when compressor is off."""
+        initial_samples = controller.learning.slope_sample_count()
+        with patch("time.time", return_value=3600.0):
+            controller.calculate_decision(
+                current_temp=19.8,
+                target_temp=20.0,
+                vtherm_slope=0.5,
+                hvac_mode="heat",
+                current_fan="med",
+                is_hvac_idle=True,
+            )
+        assert controller.learning.slope_sample_count() == initial_samples
+
+    def test_slope_samples_collected_when_not_idle(self, controller):
+        """Slope samples should be recorded when compressor is running."""
+        initial_samples = controller.learning.slope_sample_count()
+        with patch("time.time", return_value=3600.0):
+            controller.calculate_decision(
+                current_temp=19.8,
+                target_temp=20.0,
+                vtherm_slope=0.5,
+                hvac_mode="heat",
+                current_fan="med",
+                is_hvac_idle=False,
+            )
+        assert controller.learning.slope_sample_count() > initial_samples
+
+    def test_response_events_excluded_during_idle(self, controller):
+        """Response time events should NOT be recorded during idle."""
+        controller.previous_slope = 0.0
+        controller._last_change_time = 3600.0 - (5 * 60)  # 5 min ago
+        initial_events = controller.learning.response_event_count()
+        with patch("time.time", return_value=3600.0):
+            controller.calculate_decision(
+                current_temp=19.8,
+                target_temp=20.0,
+                vtherm_slope=0.5,
+                hvac_mode="heat",
+                current_fan="med",
+                is_hvac_idle=True,
+            )
+        assert controller.learning.response_event_count() == initial_events
+
+
+class TestHvacIdleCoolMode:
+    """HVAC idle also works in cooling mode."""
+
+    def test_zone_c_blocked_during_idle_cool(self, controller):
+        """Zone C (recovery in cool): step-up blocked when compressor is off."""
+        with patch("time.time", return_value=3600.0):
+            result = controller.calculate_decision(
+                current_temp=20.5,
+                target_temp=20.0,
+                vtherm_slope=0.0,
+                hvac_mode="cool",
+                current_fan="low",
+                is_hvac_idle=True,
+            )
+        assert result["fan_mode"] == "low"
+        assert "HVAC idle" in result["reason"]

--- a/tests/test_phase_detection.py
+++ b/tests/test_phase_detection.py
@@ -136,7 +136,11 @@ class TestDeadTimePatienceInZoneC:
         assert "Patience: Waiting for thermal response" in result["reason"]
 
     def test_zone_c_boosts_after_dead_time(self):
-        """After dead time expires and slope hasn't improved, zone C should boost."""
+        """After dead time expires and slope hasn't improved, zone C should boost.
+
+        With error=0.5 > 0.75*hard_error, the controller now requests +2 steps
+        for faster recovery (low → high).
+        """
         controller = SmartFanController(fan_modes=FAN_MODES, **DEFAULT_CONFIG)
         start_time = 1000.0
         controller.last_change_time = start_time
@@ -151,11 +155,15 @@ class TestDeadTimePatienceInZoneC:
                 hvac_mode="heat",
                 current_fan="low",
             )
-        assert result["fan_mode"] == "medium"
+        assert result["fan_mode"] == "high"
         assert "recovery" in result["reason"].lower()
 
     def test_zone_c_boosts_in_transient_without_waiting_for_effective_timeout(self):
-        """Once DEAD_TIME ends, zone C should boost even if no fresh slope_change arrives."""
+        """Once DEAD_TIME ends, zone C should boost even if no fresh slope_change arrives.
+
+        With error=0.5 > 0.75*hard_error, the controller now requests +2 steps
+        for faster recovery (low → high).
+        """
         controller = SmartFanController(fan_modes=FAN_MODES, **DEFAULT_CONFIG)
         start_time = 1000.0
         controller.last_change_time = start_time
@@ -174,7 +182,7 @@ class TestDeadTimePatienceInZoneC:
                 hvac_mode="heat",
                 current_fan="low",
             )
-        assert result["fan_mode"] == "medium"
+        assert result["fan_mode"] == "high"
         assert "recovery" in result["reason"].lower()
 
 
@@ -278,7 +286,11 @@ class TestCoolModePhaseDetection:
         assert "Strong favorable slope" in result["reason"]
 
     def test_zone_c_boosts_after_dead_time_cool(self):
-        """In cool mode, zone C boosts after dead time with no improvement."""
+        """In cool mode, zone C boosts after dead time with no improvement.
+
+        With error=0.5 > 0.75*hard_error, the controller now requests +2 steps
+        for faster recovery (low → high).
+        """
         controller = SmartFanController(fan_modes=FAN_MODES, **DEFAULT_CONFIG)
         start_time = 1000.0
         controller.last_change_time = start_time
@@ -293,11 +305,15 @@ class TestCoolModePhaseDetection:
                 hvac_mode="cool",
                 current_fan="low",
             )
-        assert result["fan_mode"] == "medium"
+        assert result["fan_mode"] == "high"
         assert "recovery" in result["reason"].lower()
 
     def test_zone_c_boosts_in_transient_without_waiting_for_effective_timeout_cool(self):
-        """Cool mode should also relaunch once dead time ends, even during TRANSIENT."""
+        """Cool mode should also relaunch once dead time ends, even during TRANSIENT.
+
+        With error=0.5 > 0.75*hard_error, the controller now requests +2 steps
+        for faster recovery (low → high).
+        """
         controller = SmartFanController(fan_modes=FAN_MODES, **DEFAULT_CONFIG)
         start_time = 1000.0
         controller.last_change_time = start_time
@@ -312,7 +328,7 @@ class TestCoolModePhaseDetection:
                 hvac_mode="cool",
                 current_fan="low",
             )
-        assert result["fan_mode"] == "medium"
+        assert result["fan_mode"] == "high"
         assert "recovery" in result["reason"].lower()
 
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -51,9 +51,10 @@ class TestSmartFanControllerSystem:
 
         # 3. Try to change at T + 10 minutes
         # Fan speed should be allowed to change now
+        # With error=0.5 > 0.75*hard_error, controller steps up +2 (low → high)
         with patch('time.time', return_value=start_time + 10*60):
             result = controller.calculate_decision(19.5, 20.0, -0.5, "heat", "low")
-            assert result["fan_mode"] == "medium"
+            assert result["fan_mode"] == "high"
 
     def test_emergency_overrides_interval(self, controller):
         """Test that Emergency bypasses the min_interval timer."""
@@ -91,10 +92,11 @@ class TestSmartFanControllerSystem:
     def test_hvac_mode_switch_mid_operation(self, controller):
         """Test switching from Heat to Cool mode maintains logic integrity."""
         # 1. Operating in Heat: error=0.5 > soft_error, interval expired → Strong recovery
+        # With error=0.5 > 0.75*hard_error, controller steps up +2 (low → high)
         result = controller.calculate_decision(19.5, 20.0, 0.2, "heat", "low")
         assert controller.last_hvac_mode == "heat"
         assert "Strong recovery: Drop predicted " in result["reason"]
-        assert result["fan_mode"] == "medium"
+        assert result["fan_mode"] == "high"
 
         # 2. Instant switch to Cool: hvac_mode change resets _previous_slope and
         # _thermal_acceleration so no spurious slope_change is triggered.
@@ -136,9 +138,10 @@ class TestSmartFanControllerSystem:
     def test_learning_records_current_fan_not_decided_fan(self, controller):
         """Verify that the slope sample is attributed to the ACTIVE fan mode, not the decided one."""
         controller.last_change_time = 0  # interval expired immediately
-        # current_fan='low', error=0.5 (soft zone), slope=-0.5 (falling, not improving) → boosts to 'medium'
+        # current_fan='low', error=0.5 (soft zone), slope=-0.5 (falling, not improving)
+        # With error=0.5 > 0.75*hard_error, controller steps up +2 (low → high)
         result = controller.calculate_decision(19.5, 20.0, -0.5, "heat", "low")
-        assert result["fan_mode"] == "medium"  # decision changed from low to medium
+        assert result["fan_mode"] == "high"  # decision changed from low to high
         # But the learning sample must carry 'low' (the mode that produced the measured slope)
         assert len(controller.learning.slope_samples) > 0
         sample = controller.learning.slope_samples[-1]


### PR DESCRIPTION
- [x] Fix defrost cooldown timestamp to use `time.time()` instead of `controller._now`
- [x] Add `blocking=True` to `hass.services.async_call()` for fan mode changes, and only call `controller.confirm_fan_change()` after the service call succeeds (guarded by try/except)